### PR TITLE
feat: use namespace runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -4,3 +4,5 @@ self-hosted-runner:
     - self-ubuntu-latest-arm
     - namespace-profile-default
     - namespace-profile-default-arm
+    - namespace-profile-ubuntu-latest
+    - namespace-profile-ubuntu-latest-arm

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,8 +1,4 @@
 self-hosted-runner:
   labels:
-    - self-ubuntu-latest
-    - self-ubuntu-latest-arm
-    - namespace-profile-default
-    - namespace-profile-default-arm
-    - namespace-profile-ubuntu-latest
-    - namespace-profile-ubuntu-latest-arm
+    - namespace-profile-*
+

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,6 @@
 self-hosted-runner:
   labels:
     - self-ubuntu-latest
+    - self-ubuntu-latest-arm
+    - namespace-profile-default
+    - namespace-profile-default-arm

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,8 +125,9 @@ jobs:
 
   # We now want to copy the UBI image to ghcr.io/fluentdo/agent:version and
   # the distroless image to ghcr.io/fluentdo/agent:version-slim
-  copy-top-images:
+  copy-common-images:
     needs:
+      - get-meta
       - build-image
     runs-on: ubuntu-latest
     permissions:
@@ -139,7 +140,7 @@ jobs:
       UBI_IMAGE_NAME: ghcr.io/fluentdo/agent/ubi
       DISTROLESS_IMAGE_NAME: ghcr.io/fluentdo/agent/debian
       OUTPUT_IMAGE_NAME: ghcr.io/fluentdo/agent
-      TAG: ${{ needs.build-image.outputs.version }}
+      TAG: ${{ needs.get-meta.outputs.version }}
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -147,12 +148,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to the docker.io registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Promote UBI images
         run: |
@@ -172,7 +167,7 @@ jobs:
 
       - name: Promote distroless images
         run: |
-          docker pull "$UBI_IMAGE_NAME:$TAG"
+          docker pull "$DISTROLESS_IMAGE_NAME:$TAG"
           docker run --rm  \
             quay.io/skopeo/stable:latest \
             copy \
@@ -209,7 +204,8 @@ jobs:
       matrix:
         kind-version: ${{ fromJson(needs.get-meta.outputs.kind-versions) }}
         image-base:
-          - "ghcr.io/fluentdo/agent"
+          - "ghcr.io/fluentdo/agent/ubi"
+          - "ghcr.io/fluentdo/agent/debian"
 
   build-linux:
     # Only build Linux packages if we are not a pull request or have a label set
@@ -229,6 +225,7 @@ jobs:
     needs:
       - get-meta
       - build-image
+      - copy-common-images
       - build-linux
     runs-on: ubuntu-latest
     permissions:
@@ -260,8 +257,16 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ${{ needs.build-image.outputs.tag }}
+          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}"
           artifact-name: image-sbom.spdx
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          output-file: output/image-sbom.spdx
+
+      - uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}"
+          artifact-name: image-slim-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           output-file: output/image-sbom.spdx
@@ -272,10 +277,16 @@ jobs:
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-            "docker://${{ needs.build-image.outputs.tag }}" \
+            "docker://ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}" \
             "oci-archive:output/fluent-do-agent-container.tar"
-          tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar
-          rm -f output/fluent-do-agent-container.tar
+          skopeo copy \
+            --all \
+            --remove-signatures \
+            --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "docker://ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}-slim" \
+            "oci-archive:output/fluent-do-agent-container-slim.tar"
+          tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar"
+          rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar"
         shell: bash
 
       - name: Construct release info
@@ -325,7 +336,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: output/
-          destination: lts_deliverables/${{ needs.get-meta.outputs.build-type }}/${{ needs.get-meta.outputs.version }}/
+          destination: fluentdo-agent-${{ needs.get-meta.outputs.build-type }}/${{ needs.get-meta.outputs.version }}/
 
   update-docs:
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,7 +227,6 @@ jobs:
     needs:
       - get-meta
       - build-image
-      - copy-common-images
       - build-linux
     runs-on: ubuntu-latest
     permissions:
@@ -238,7 +237,6 @@ jobs:
     env:
       UBI_IMAGE_NAME: ghcr.io/fluentdo/agent/ubi
       DISTROLESS_IMAGE_NAME: ghcr.io/fluentdo/agent/debian
-      OUTPUT_IMAGE_NAME: ghcr.io/fluentdo/agent
       TAG: ${{ needs.build-image.outputs.version }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,7 +140,7 @@ jobs:
       UBI_IMAGE_NAME: ghcr.io/fluentdo/agent/ubi
       DISTROLESS_IMAGE_NAME: ghcr.io/fluentdo/agent/debian
       OUTPUT_IMAGE_NAME: ghcr.io/fluentdo/agent
-      TAG: ${{ needs.get-meta.outputs.version }}
+      TAG: ${{ needs.build-image.outputs.version }}
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -188,7 +188,7 @@ jobs:
     with:
       kind-version: ${{ matrix.kind-version }}
       image: ${{ matrix.image-base }}
-      image-tag: ${{ needs.get-meta.outputs.version }}
+      image-tag: ${{ needs.build-image.outputs.version }}
       ref: ${{ github.ref }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -257,7 +257,7 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}
+          image: ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}
           artifact-name: image-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
@@ -265,7 +265,7 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}
+          image: ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}
           artifact-name: image-slim-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
@@ -277,13 +277,13 @@ jobs:
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-            "docker://ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}" \
+            "docker://ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}" \
             "oci-archive:output/fluent-do-agent-container.tar"
           skopeo copy \
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-            "docker://ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}-slim" \
+            "docker://ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}-slim" \
             "oci-archive:output/fluent-do-agent-container-slim.tar"
           tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
           rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -188,7 +188,7 @@ jobs:
     with:
       kind-version: ${{ matrix.kind-version }}
       image: ${{ matrix.image-base }}
-      image-tag: ${{ needs.build-image.outputs.version }}
+      image-tag: ${{ needs.get-meta.outputs.version }}
       ref: ${{ github.ref }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -257,7 +257,7 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}"
+          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}
           artifact-name: image-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
@@ -265,7 +265,7 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}"
+          image: ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}
           artifact-name: image-slim-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
@@ -285,8 +285,8 @@ jobs:
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
             "docker://ghcr.io/fluentdo/agent:${{ needs.get-meta.outputs.version }}-slim" \
             "oci-archive:output/fluent-do-agent-container-slim.tar"
-          tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar"
-          rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar"
+          tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
+          rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
         shell: bash
 
       - name: Construct release info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,13 +8,11 @@ on:
       - synchronize
       - reopened
       - labeled
-
-  # Only do full build nightly and for releases
   push:
+    branches:
+      - main
     tags:
       - v*
-  schedule:
-    - cron: '0 0 * * *' # Every day at midnight UTC
 
 # Cancel any running jobs for PRs on a new commit
 concurrency:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,6 @@ jobs:
       fail-fast: false
       matrix:
         image-base:
-          - "ghcr.io/fluentdo/agent"
           - "ghcr.io/fluentdo/agent/ubi"
           - "ghcr.io/fluentdo/agent/debian"
     permissions:
@@ -124,6 +123,70 @@ jobs:
 
       # Pick the Dockerfile to use for each image
       definition: ${{ (contains(matrix.image-base, 'debian') && 'Dockerfile.debian') || 'Dockerfile.ubi' }}
+
+
+  # We now want to copy the UBI image to ghcr.io/fluentdo/agent:version and
+  # the distroless image to ghcr.io/fluentdo/agent:version-slim
+  copy-top-images:
+    needs:
+      - build-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+    env:
+      UBI_IMAGE_NAME: ghcr.io/fluentdo/agent/ubi
+      DISTROLESS_IMAGE_NAME: ghcr.io/fluentdo/agent/debian
+      OUTPUT_IMAGE_NAME: ghcr.io/fluentdo/agent
+      TAG: ${{ needs.build-image.outputs.version }}
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the docker.io registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Promote UBI images
+        run: |
+          docker pull "$UBI_IMAGE_NAME:$TAG"
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$DEST_CREDS" \
+              "docker://$UBI_IMAGE_NAME:$TAG" \
+              "docker://$OUTPUT_IMAGE_NAME:$TAG"
+        env:
+          DEST_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Promote distroless images
+        run: |
+          docker pull "$UBI_IMAGE_NAME:$TAG"
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$DEST_CREDS" \
+              "docker://$DISTROLESS_IMAGE_NAME:$TAG" \
+              "docker://$OUTPUT_IMAGE_NAME:${TAG:?}-slim"
+        env:
+          DEST_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+        shell: bash
 
   test_kubernetes:
     # Only run Kubernetes tests if we are not a pull request or have a label set

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,10 +122,12 @@ jobs:
       # Pick the Dockerfile to use for each image
       definition: ${{ (contains(matrix.image-base, 'debian') && 'Dockerfile.debian') || 'Dockerfile.ubi' }}
 
-
-  # We now want to copy the UBI image to ghcr.io/fluentdo/agent:version and
+  # We want to copy the UBI image to ghcr.io/fluentdo/agent:version and
   # the distroless image to ghcr.io/fluentdo/agent:version-slim
   copy-common-images:
+    # Only run for releases to reduce unnecessary load on the registry
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    name: Copy common container images to main image names
     needs:
       - get-meta
       - build-image
@@ -233,6 +235,11 @@ jobs:
       actions: read
       contents: write
       id-token: write
+    env:
+      UBI_IMAGE_NAME: ghcr.io/fluentdo/agent/ubi
+      DISTROLESS_IMAGE_NAME: ghcr.io/fluentdo/agent/debian
+      OUTPUT_IMAGE_NAME: ghcr.io/fluentdo/agent
+      TAG: ${{ needs.build-image.outputs.version }}
     steps:
       - uses: actions/checkout@v5
 
@@ -257,19 +264,19 @@ jobs:
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}
-          artifact-name: image-sbom.spdx
+          image: ${{ env.UBI_IMAGE_NAME }}:${{ env.TAG }}
+          artifact-name: image-ubi-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          output-file: output/image-sbom.spdx
+          output-file: output/image-ubi-sbom.spdx
 
       - uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}
-          artifact-name: image-slim-sbom.spdx
+          image: ${{ env.DISTROLESS_IMAGE_NAME }}:${{ env.TAG }}
+          artifact-name: image-debian-sbom.spdx
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          output-file: output/image-sbom.spdx
+          output-file: output/image-debian-sbom.spdx
 
       - name: Save image as tarball
         run: |
@@ -277,13 +284,13 @@ jobs:
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-            "docker://ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}" \
+            "docker://${{ env.UBI_IMAGE_NAME }}:${{ env.TAG }}" \
             "oci-archive:output/fluent-do-agent-container.tar"
           skopeo copy \
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-            "docker://ghcr.io/fluentdo/agent:${{ needs.build-image.outputs.version }}-slim" \
+            "docker://${{ env.DISTROLESS_IMAGE_NAME }}:${{ env.TAG }}" \
             "oci-archive:output/fluent-do-agent-container-slim.tar"
           tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
           rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
@@ -313,7 +320,8 @@ jobs:
 
             Targets: ${{ needs.get-meta.outputs.linux-targets }}
             Images:
-              - ${{ needs.build-image.outputs.tag }}
+              - ${{ env.UBI_IMAGE_NAME }}:${{ env.TAG }}
+              - ${{ env.DISTROLESS_IMAGE_NAME }}:${{ env.TAG }}
           files: |
             output/*.spdx
             output/*.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,11 +8,13 @@ on:
       - synchronize
       - reopened
       - labeled
+
+  # Only do full build nightly and for releases
   push:
-    branches:
-      - main
     tags:
       - v*
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight UTC
 
 # Cancel any running jobs for PRs on a new commit
 concurrency:
@@ -73,8 +75,6 @@ jobs:
           echo "Using version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         shell: bash
-        env:
-          INPUT_VERSION: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') && github.ref_name) || '' }}
 
       - name: Extract the configuration from the JSON file
         # Read from the file and remove newline characters: https://stackoverflow.com/a/64627966

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -75,6 +75,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to the docker.io registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push by digest the standard ${{ matrix.target }} image
         id: production
         uses: docker/build-push-action@v6

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -75,12 +75,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the docker.io registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push by digest the standard ${{ matrix.target }} image
         id: production
         uses: docker/build-push-action@v6

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -53,7 +53,7 @@ jobs:
         target:
           - production
     name: ${{ matrix.platform }}/${{ matrix.target }} container image build
-    runs-on: ${{ (contains(matrix.platform, 'arm') && 'self-ubuntu-latest-arm') || 'self-ubuntu-latest' }}
+    runs-on: ${{ (contains(matrix.platform, 'arm') && 'namespace-profile-default-arm') || 'namespace-profile-default' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -53,7 +53,7 @@ jobs:
         target:
           - production
     name: ${{ matrix.platform }}/${{ matrix.target }} container image build
-    runs-on: ${{ (contains(matrix.platform, 'arm') && 'namespace-profile-default-arm64') || 'namespace-profile-default' }}
+    runs-on: ${{ (contains(matrix.platform, 'arm') && 'namespace-profile-ubuntu-latest-arm') || 'namespace-profile-ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -53,7 +53,7 @@ jobs:
         target:
           - production
     name: ${{ matrix.platform }}/${{ matrix.target }} container image build
-    runs-on: ${{ (contains(matrix.platform, 'arm') && 'namespace-profile-default-arm') || 'namespace-profile-default' }}
+    runs-on: ${{ (contains(matrix.platform, 'arm') && 'namespace-profile-default-arm64') || 'namespace-profile-default' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -62,11 +62,12 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # Not required on Namespace and can break builds
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -137,7 +137,7 @@ jobs:
           tags: |
             # Ensure we strip the 'v' prefix
             type=semver,pattern={{version}},event=tag
-            Add the input version as well for releases
+            # Add the input version as well for releases
             type=raw,value=${{ inputs.version }},event=tag
             # defaults for others
             type=schedule

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-packages:
     name: agent - ${{ matrix.distro }} package build and upload
-    runs-on: ${{ (contains(matrix.distro, 'arm') && 'self-ubuntu-latest-arm') || 'self-ubuntu-latest' }}
+    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-default-arm') || 'namespace-profile-default' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -57,12 +57,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the docker.io registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       # Use the upstream packaging script to keep consistent and up-to-date
       - name: ${{ matrix.distro }} artefacts
         run: |

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -35,8 +35,12 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: FluentDo/agent
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Not required on Namespace and can break builds
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
       - name: Format the matrix string
         uses: frabert/replace-string-action@v2.5
@@ -46,9 +50,6 @@ jobs:
           string: "${{ matrix.distro }}"
           replace-with: "$1-$2"
           flags: "g"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to the GHCR registry
         uses: docker/login-action@v3

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-packages:
     name: agent - ${{ matrix.distro }} package build and upload
-    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-default-arm') || 'namespace-profile-default' }}
+    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-default-arm64') || 'namespace-profile-default' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -57,6 +57,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to the docker.io registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Use the upstream packaging script to keep consistent and up-to-date
       - name: ${{ matrix.distro }} artefacts
         run: |
@@ -68,7 +74,6 @@ jobs:
           FLB_DISTRO: ${{ matrix.distro }}
           FLB_OUT_DIR: agent
           FLB_NIGHTLY_BUILD: ${{ inputs.nightly-build-info }}
-          FLB_ARG: --build-arg FLB_OUT_PGSQL=Off # Disable PostgreSQL output plugin
         working-directory: source/packaging
         shell: bash
 

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-packages:
     name: agent - ${{ matrix.distro }} package build and upload
-    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-default-arm64') || 'namespace-profile-default' }}
+    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-ubuntu-latest-arm') || 'namespace-profile-ubuntu-latest' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-packages:
     name: agent - ${{ matrix.distro }} package build and upload
-    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-ubuntu-latest-arm') || 'namespace-profile-ubuntu-latest' }}
+    runs-on: ${{ (contains(matrix.distro, 'arm') && 'namespace-profile-ubuntu-latest-arm') || (contains(matrix.distro, 'centos/6') && 'namespace-profile-ubuntu-latest-4cpu-16gb') || 'namespace-profile-ubuntu-latest' }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -103,35 +103,36 @@ jobs:
           FLB_CHUNK_TRACE: Off
 
           # Pass all the above as build args to ensure they are used in the docker build, this is the way build.sh passes them.
-          FLB_ARG: '--build-arg FLB_IN_CALYPTIA_FLEET=Off
-                    --build-arg FLB_IN_DOCKER=Off
-                    --build-arg FLB_IN_DOCKER_EVENTS=Off
-                    --build-arg FLB_IN_EXEC_WASI=Off
-                    --build-arg FLB_IN_MQTT=Off
-                    --build-arg FLB_IN_NETIF=Off
-                    --build-arg FLB_IN_NGINX_EXPORTER_METRICS=Off
-                    --build-arg FLB_IN_SERIAL=Off
-                    --build-arg FLB_IN_THERMAL=Off
-                    --build-arg FLB_FILTER_ALTER_SIZE=Off
-                    --build-arg FLB_FILTER_CHECKLIST=Off
-                    --build-arg FLB_FILTER_GEOIP2=Off
-                    --build-arg FLB_FILTER_NIGHTFALL=Off
-                    --build-arg FLB_FILTER_WASM=Off
-                    --build-arg FLB_OUT_CALYPTIA=Off
-                    --build-arg FLB_OUT_LOGDNA=Off
-                    --build-arg FLB_OUT_PGSQL=Off
-                    --build-arg FLB_OUT_TD=Off
-                    --build-arg FLB_OUT_VIVO_EXPORTER=Off
-                    --build-arg FLB_STREAM_PROCESSOR=Off
-                    --build-arg FLB_WASM=Off
-                    --build-arg FLB_ZIG=Off
-                    --build-arg FLB_PROXY_GO=Off
-                    --build-arg FLB_SHARED_LIB=Off
-                    --build-arg FLB_EXAMPLES=Off
-                    --build-arg FLB_RELEASE=On
-                    --build-arg FLB_SIMD=On
-                    --build-arg FLB_TRACE=Off
-                    --build-arg FLB_CHUNK_TRACE=Off '
+          FLB_ARG: |
+            --build-arg FLB_IN_CALYPTIA_FLEET=Off
+            --build-arg FLB_IN_DOCKER=Off
+            --build-arg FLB_IN_DOCKER_EVENTS=Off
+            --build-arg FLB_IN_EXEC_WASI=Off
+            --build-arg FLB_IN_MQTT=Off
+            --build-arg FLB_IN_NETIF=Off
+            --build-arg FLB_IN_NGINX_EXPORTER_METRICS=Off
+            --build-arg FLB_IN_SERIAL=Off
+            --build-arg FLB_IN_THERMAL=Off
+            --build-arg FLB_FILTER_ALTER_SIZE=Off
+            --build-arg FLB_FILTER_CHECKLIST=Off
+            --build-arg FLB_FILTER_GEOIP2=Off
+            --build-arg FLB_FILTER_NIGHTFALL=Off
+            --build-arg FLB_FILTER_WASM=Off
+            --build-arg FLB_OUT_CALYPTIA=Off
+            --build-arg FLB_OUT_LOGDNA=Off
+            --build-arg FLB_OUT_PGSQL=Off
+            --build-arg FLB_OUT_TD=Off
+            --build-arg FLB_OUT_VIVO_EXPORTER=Off
+            --build-arg FLB_STREAM_PROCESSOR=Off
+            --build-arg FLB_WASM=Off
+            --build-arg FLB_ZIG=Off
+            --build-arg FLB_PROXY_GO=Off
+            --build-arg FLB_SHARED_LIB=Off
+            --build-arg FLB_EXAMPLES=Off
+            --build-arg FLB_RELEASE=On
+            --build-arg FLB_SIMD=On
+            --build-arg FLB_TRACE=Off
+            --build-arg FLB_CHUNK_TRACE=Off
         working-directory: source/packaging
         shell: bash
 

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -74,6 +74,69 @@ jobs:
           FLB_DISTRO: ${{ matrix.distro }}
           FLB_OUT_DIR: agent
           FLB_NIGHTLY_BUILD: ${{ inputs.nightly-build-info }}
+
+          # Ensure we do not use any defaults from upstream, use our hardened config.
+          FLB_IN_CALYPTIA_FLEET: Off
+          FLB_IN_DOCKER: Off
+          FLB_IN_DOCKER_EVENTS: Off
+          FLB_IN_EXEC_WASI: Off
+          FLB_IN_MQTT: Off
+          FLB_IN_NETIF: Off
+          FLB_IN_NGINX_EXPORTER_METRICS: Off
+          FLB_IN_SERIAL: Off
+          FLB_IN_THERMAL: Off
+          FLB_FILTER_ALTER_SIZE: Off
+          FLB_FILTER_CHECKLIST: Off
+          FLB_FILTER_GEOIP2: Off
+          FLB_FILTER_NIGHTFALL: Off
+          FLB_FILTER_WASM: Off
+          FLB_OUT_CALYPTIA: Off
+          FLB_OUT_LOGDNA: Off
+          FLB_OUT_PGSQL: Off
+          FLB_OUT_TD: Off
+          FLB_OUT_VIVO_EXPORTER: Off
+
+          FLB_STREAM_PROCESSOR: Off
+          FLB_WASM: Off
+          FLB_ZIG: Off
+          FLB_PROXY_GO: Off
+          FLB_SHARED_LIB: Off
+          FLB_EXAMPLES: Off
+          FLB_RELEASE: On
+          FLB_SIMD: On
+          FLB_TRACE: Off
+          FLB_CHUNK_TRACE: Off
+
+          # Pass all the above as build args to ensure they are used in the docker build, this is the way build.sh passes them.
+          FLB_ARG: '--build-arg FLB_IN_CALYPTIA_FLEET=Off
+                    --build-arg FLB_IN_DOCKER=Off
+                    --build-arg FLB_IN_DOCKER_EVENTS=Off
+                    --build-arg FLB_IN_EXEC_WASI=Off
+                    --build-arg FLB_IN_MQTT=Off
+                    --build-arg FLB_IN_NETIF=Off
+                    --build-arg FLB_IN_NGINX_EXPORTER_METRICS=Off
+                    --build-arg FLB_IN_SERIAL=Off
+                    --build-arg FLB_IN_THERMAL=Off
+                    --build-arg FLB_FILTER_ALTER_SIZE=Off
+                    --build-arg FLB_FILTER_CHECKLIST=Off
+                    --build-arg FLB_FILTER_GEOIP2=Off
+                    --build-arg FLB_FILTER_NIGHTFALL=Off
+                    --build-arg FLB_FILTER_WASM=Off
+                    --build-arg FLB_OUT_CALYPTIA=Off
+                    --build-arg FLB_OUT_LOGDNA=Off
+                    --build-arg FLB_OUT_PGSQL=Off
+                    --build-arg FLB_OUT_TD=Off
+                    --build-arg FLB_OUT_VIVO_EXPORTER=Off
+                    --build-arg FLB_STREAM_PROCESSOR=Off
+                    --build-arg FLB_WASM=Off
+                    --build-arg FLB_ZIG=Off
+                    --build-arg FLB_PROXY_GO=Off
+                    --build-arg FLB_SHARED_LIB=Off
+                    --build-arg FLB_EXAMPLES=Off
+                    --build-arg FLB_RELEASE=On
+                    --build-arg FLB_SIMD=On
+                    --build-arg FLB_TRACE=Off
+                    --build-arg FLB_CHUNK_TRACE=Off '
         working-directory: source/packaging
         shell: bash
 


### PR DESCRIPTION
Evaluate namespace runner usage: looks like we are around 3000 minutes a week so hopefully their initial team plan is good for us ($100 for 100000 minutes a month) and they have Windows runners in-beta. Note we must remove qemu-setup and setup-buildx actions as part of this so commented out to simplify if we want to revert.

Ensure we pass the right hardening values to package builds - this should be refactored in future but is added now as a quick fix.

Rather than build the UBI container twice, instead we use skopeo to copy it to /agent:<version> and also a new /agent:<version>-slim for the distroless variant.

Some other minor CI tweaks included too.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Summary</h3>

This PR migrates the FluentDo Agent CI/CD pipeline from standard GitHub Actions runners to namespace runners for cost optimization and better performance control. The changes are motivated by the team's usage of approximately 3000 minutes per week, which fits well within namespace runners' $100/month plan for 100,000 minutes.

The migration involves several key modifications:

1. **Runner Configuration Updates**: All workflows now use `namespace-profile-*` runners instead of standard GitHub runners, with a special high-performance `namespace-profile-ubuntu-latest-4cpu-16gb` runner specifically for CentOS 6 builds that require additional resources.

2. **Build Optimization**: The PR removes duplicate container builds by using skopeo to copy the UBI container to create both `/agent:<version>` and `/agent:<version>-slim` variants, eliminating the need to build the UBI container twice.

3. **Conditional Job Execution**: The `copy-common-images` job now only runs on releases (tags starting with 'refs/tags/v') to reduce unnecessary CI operations and costs during development.

4. **Security Hardening**: Comprehensive build-time hardening is implemented through FLB_ARG environment variables that disable various Fluent Bit features to create a more secure build with reduced attack surface.

5. **Infrastructure Simplification**: QEMU and Docker Buildx setup actions are commented out since namespace runners handle these capabilities differently.

The changes integrate well with the existing FluentDo Agent codebase structure, maintaining compatibility with the multi-stage Dockerfiles (`Dockerfile.ubi`, `Dockerfile.debian`) and build configuration (`build-config.json`) while optimizing the CI pipeline for cost-effectiveness and performance.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->