### PR TITLE
feat: add Windows build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,7 +201,7 @@ jobs:
 
   build-linux:
     # Only build Linux packages if we are not a pull request or have a label set
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-packages') }}
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-packages') || contains(github.event.pull_request.labels.*.name, 'build-linux')}}
     uses: ./.github/workflows/call-build-linux-packages.yaml
     needs:
       - get-meta
@@ -210,6 +210,16 @@ jobs:
       target-matrix: ${{ needs.get-meta.outputs.linux-targets }}
       nightly-build-info: ${{ needs.get-meta.outputs.date }}
 
+  build-windows:
+    # Only build Linux packages if we are not a pull request or have a label set
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-packages') || contains(github.event.pull_request.labels.*.name, 'build-windows') }}
+    uses: ./.github/workflows/call-build-windows-packages.yaml
+    needs:
+      - get-meta
+    with:
+      ref: ${{ github.ref }}
+      target-matrix: ${{ needs.get-meta.outputs.linux-targets }}
+      nightly-build-info: ${{ needs.get-meta.outputs.date }}
 
   # Placeholder to make it simple to create a status check on this, do not change name
   tests-complete:
@@ -231,6 +241,10 @@ jobs:
       - get-meta
       - build-image
       - build-linux
+      - build-windows
+      # Deliberately exclude the following for a release and also to dry run PRs
+      # - copy-common-images
+      # - tests-complete
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -244,13 +258,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Download all artefacts
         uses: actions/download-artifact@v5
         with:
@@ -262,6 +269,13 @@ jobs:
         run: |
           tar -czvf $GITHUB_WORKSPACE/deliverables.tar.gz -C output .
         shell: bash
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: anchore/sbom-action@v0
         with:
@@ -300,10 +314,11 @@ jobs:
       - name: Construct release info
         # Add target info and OSS version to new JSON file
         run: |
-          jq '. += { "oss_version": "${{ needs.get-meta.outputs.oss-version }}"}' build-config.json > output/release.json
+          jq '. += { "oss_version": "${{ needs.get-meta.outputs.oss-version }}"}' build-config.json | tee output/release.json
         shell: bash
 
       - name: Debug
+        if: always()
         run: ls -lR
         shell: bash
 

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -1,0 +1,115 @@
+---
+name: Build Windows packages
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of Fluent Bit to create.
+        type: string
+        required: true
+      ref:
+        description: The commit, tag or branch of Fluent Bit to checkout for building that creates the version above.
+        type: string
+        required: true
+    secrets:
+      token:
+        description: The Github token or similar to authenticate with.
+        required: true
+jobs:
+
+  call-build-windows-package:
+    runs-on: namespace-profile-windows-server-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Windows 64bit"
+            arch: x64
+            cmake_additional_opt: ""
+            vcpkg_triplet: x64-windows-static
+            cmake_version: "3.31.6"
+    permissions:
+      contents: read
+    # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.
+    env:
+      PATH: C:\ProgramData\Chocolatey\bin;c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin;C:\vcpkg;
+    steps:
+      - name: Checkout ${{ inputs.ref }} code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          repository: FluentDo/agent
+
+      - name: Get dependencies
+        run: |
+          Invoke-WebRequest -OutFile winflexbison.zip $env:WINFLEXBISON
+          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
+          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
+          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
+          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
+          choco install cmake --version "${{ matrix.config.cmake_version }}" --force
+        env:
+          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
+        shell: pwsh
+
+      - name: Set up with Developer Command Prompt for Microsoft Visual C++
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.arch }}
+
+      - name: Get gzip command and nsis w/ chocolatey
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install gzip nsis -y
+
+      - name: Restore cached packages of vcpkg
+        id: cache-vcpkg-sources
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            C:\vcpkg\installed
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-installed-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-installed-
+          enableCrossOsArchive: false
+
+      - name: Build openssl with vcpkg
+        run: |
+          C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
+
+      - name: Build libyaml with vcpkg
+        run: |
+          C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
+
+      - name: Upgrade any outdated vcpkg packages
+        run: |
+          C:\vcpkg\vcpkg upgrade --no-dry-run
+        shell: cmd
+
+      - name: Save packages of vcpkg
+        id: save-vcpkg-sources
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            C:\vcpkg\installed
+          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
+          enableCrossOsArchive: false
+
+      - name: Build Fluent Bit packages
+        run: |
+          cmake -G "NMake Makefiles" -DOPENSSL_ROOT_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' ${{ matrix.config.cmake_additional_opt }} -DFLB_LIBYAML_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' ../
+          cmake --build .
+          cpack
+        working-directory: build
+
+      - name: Upload build packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-windows-${{ matrix.config.arch }}
+          path: |
+            build/*-bit-*.exe
+            build/*-bit-*.msi
+            build/*-bit-*.zip
+          if-no-files-found: error


### PR DESCRIPTION
Added support for building Windows packages based on upstream but with some optimisations.

Constrained PR building of packages with new labels:
- `build-linux` builds only the Linux packages
- `build-windows` builds only the Windows packages
- `build-packages` builds everything as it did before