### PR TITLE
fix: update CentOS 6 dependencies to prevent failure

### DIFF
--- a/custom/packaging/distros/centos/6/Dockerfile
+++ b/custom/packaging/distros/centos/6/Dockerfile
@@ -53,10 +53,10 @@ WORKDIR /m4
 RUN ./configure && make -j "$(getconf _NPROCESSORS_ONLN)" && make install
 
 # Bison needs to be built from source unfortunately
-ARG BISON_VER=3.7.2
-ARG BISON_URL=http://ftp.gnu.org/gnu/bison
+ARG BISON_VER=3.8.2
+ARG BISON_URL=https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/
 ARG FLEX_VER=2.6.4
-ARG FLEX_URL=https://github.com/westes/flex/files/981163
+ARG FLEX_URL=https://github.com/westes/flex/releases/download/v${FLEX_VER}
 ADD ${BISON_URL}/bison-${BISON_VER}.tar.gz /bison/
 ADD ${FLEX_URL}/flex-${FLEX_VER}.tar.gz /flex/
 RUN tar -xzvf /bison/bison-${BISON_VER}.tar.gz -C /bison/ && tar -xzvf /flex/flex-${FLEX_VER}.tar.gz -C /flex/

--- a/custom/packaging/distros/suse/Dockerfile
+++ b/custom/packaging/distros/suse/Dockerfile
@@ -81,7 +81,7 @@ RUN CMAKE_ARCH=$(uname -m); \
     ln -sf /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Bison needs to be built from source unfortunately as at least one target does not provide it so we want to be common for all
-ARG BISON_VER=3.7.2
+ARG BISON_VER=3.8.2
 ARG BISON_URL=https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/
 ARG FLEX_VER=2.6.4
 ARG FLEX_URL=https://github.com/westes/flex/files/981163

--- a/source/packaging/distros/centos/6/Dockerfile
+++ b/source/packaging/distros/centos/6/Dockerfile
@@ -53,10 +53,10 @@ WORKDIR /m4
 RUN ./configure && make -j "$(getconf _NPROCESSORS_ONLN)" && make install
 
 # Bison needs to be built from source unfortunately
-ARG BISON_VER=3.7.2
-ARG BISON_URL=http://ftp.gnu.org/gnu/bison
+ARG BISON_VER=3.8.2
+ARG BISON_URL=https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/
 ARG FLEX_VER=2.6.4
-ARG FLEX_URL=https://github.com/westes/flex/files/981163
+ARG FLEX_URL=https://github.com/westes/flex/releases/download/v${FLEX_VER}
 ADD ${BISON_URL}/bison-${BISON_VER}.tar.gz /bison/
 ADD ${FLEX_URL}/flex-${FLEX_VER}.tar.gz /flex/
 RUN tar -xzvf /bison/bison-${BISON_VER}.tar.gz -C /bison/ && tar -xzvf /flex/flex-${FLEX_VER}.tar.gz -C /flex/

--- a/source/packaging/distros/suse/Dockerfile
+++ b/source/packaging/distros/suse/Dockerfile
@@ -81,7 +81,7 @@ RUN CMAKE_ARCH=$(uname -m); \
     ln -sf /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Bison needs to be built from source unfortunately as at least one target does not provide it so we want to be common for all
-ARG BISON_VER=3.7.2
+ARG BISON_VER=3.8.2
 ARG BISON_URL=https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/
 ARG FLEX_VER=2.6.4
 ARG FLEX_URL=https://github.com/westes/flex/files/981163


### PR DESCRIPTION
Resolve build failures being seen with using the GNU site directly, also update to latest versions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-04 14:43:49 UTC

<h3>Summary</h3>
This PR addresses build failures in the FluentDo Agent by updating dependency management for legacy CentOS 6 and SUSE distributions. The primary issue was unreliable access to the GNU FTP site when downloading build dependencies, which was causing intermittent build failures.

The changes update two critical build dependencies:
1. **Bison**: Upgraded from version 3.7.2 to 3.8.2 across all affected Dockerfiles
2. **Build source reliability**: Switched from direct GNU FTP access to mirrorservice.org, a more reliable mirror service
3. **Flex URL improvement**: Updated the Flex download URL from a hardcoded GitHub file ID to the proper GitHub releases API endpoint

These changes are implemented across multiple distribution Dockerfiles (`custom/packaging/distros/centos/6/Dockerfile`, `source/packaging/distros/centos/6/Dockerfile`, and both SUSE Dockerfiles) to maintain consistency in the build environment. The FluentDo Agent uses these Dockerfiles to create container images for different Linux distributions, and these dependency updates ensure reliable builds without changing the agent's core functionality.

The changes are part of maintaining the legacy build pipeline, particularly for CentOS 6 which requires building tools from source due to the age of the base system. This is a maintenance update that improves build reliability while keeping the agent's functionality intact.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| custom/packaging/distros/centos/6/Dockerfile | 4/5 | Updated Bison (3.7.2→3.8.2) and Flex URLs to use reliable mirror sources instead of GNU FTP |
| source/packaging/distros/centos/6/Dockerfile | 4/5 | Updated Bison version and switched download URLs to more reliable mirror services |
| custom/packaging/distros/suse/Dockerfile | 4/5 | Updated Bison version from 3.7.2 to 3.8.2 for consistency with other distributions |
| source/packaging/distros/suse/Dockerfile | 4/5 | Updated Bison version to match other distribution targets |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it only updates build dependencies without changing core functionality
- Score reflects reliable dependency updates and infrastructure improvements that address known build failures
- Pay attention to the duplicate Dockerfile paths to ensure both custom and source variants are properly maintained

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Docker as "Docker Build System"
    participant CMake as "CMake Build Tool"
    participant DownloadSites as "Download Sites (GitHub, MirrorService)"
    participant Compiler as "GCC Compiler"
    participant PackageManager as "Package Manager (yum/zypper)"

    User->>Docker: "Build Fluent-bit for CentOS 6/SUSE"
    Docker->>PackageManager: "Install base dependencies"
    PackageManager-->>Docker: "Dependencies installed"
    
    Docker->>DownloadSites: "Download CMake binary"
    DownloadSites-->>Docker: "CMake downloaded"
    Docker->>Docker: "Install CMake to /opt/cmake"
    
    Docker->>DownloadSites: "Download M4 source (CentOS 6 only)"
    DownloadSites-->>Docker: "M4 source downloaded"
    Docker->>Compiler: "Build and install M4"
    Compiler-->>Docker: "M4 built"
    
    Docker->>DownloadSites: "Download Bison/Flex sources"
    DownloadSites-->>Docker: "Bison/Flex sources downloaded"
    Docker->>Compiler: "Build and install Bison"
    Compiler-->>Docker: "Bison built"
    Docker->>Compiler: "Build and install Flex"
    Compiler-->>Docker: "Flex built"
    
    Docker->>DownloadSites: "Download OpenSSL 3.5.2 source"
    DownloadSites-->>Docker: "OpenSSL source downloaded"
    Docker->>Compiler: "Build and install OpenSSL"
    Compiler-->>Docker: "OpenSSL built"
    
    alt CentOS 6 only
        Docker->>DownloadSites: "Download libssh2 source"
        DownloadSites-->>Docker: "libssh2 source downloaded"
        Docker->>Compiler: "Build libssh2 with static linking"
        Compiler-->>Docker: "libssh2 built"
        
        Docker->>DownloadSites: "Download libgit2 source"
        DownloadSites-->>Docker: "libgit2 source downloaded"
        Docker->>CMake: "Build libgit2 with cmake"
        CMake-->>Docker: "libgit2 built"
    end
    
    Docker->>Docker: "Copy Fluent-bit source code"
    Docker->>CMake: "Configure Fluent-bit build with OpenSSL"
    CMake-->>Docker: "Build configured"
    Docker->>Compiler: "Compile Fluent-bit"
    Compiler-->>Docker: "Fluent-bit compiled"
    Docker->>CMake: "Create RPM package"
    CMake-->>Docker: "RPM package created"
    Docker-->>User: "Build complete with RPM output"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->