### PR TITLE
feat: support Red Hat certification

### DIFF
--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -76,6 +76,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Used to set default labels and the like to overwrite base image ones
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+
       - name: Build and push by digest the standard ${{ matrix.target }} image
         id: production
         uses: docker/build-push-action@v6
@@ -86,6 +91,8 @@ jobs:
           outputs: type=image,name=${{ inputs.image-base }},push-by-digest=true,name-canonical=true,push=true
           platforms: linux/${{ matrix.platform }}
           target: ${{ matrix.target }}
+          # Make sure we push our custom labels to the image
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             FLUENTDO_AGENT_VERSION=${{ inputs.version }}
           provenance: false

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -80,6 +80,13 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
+        with:
+          labels: |
+            build-date={{date 'YYYYMMDD-HHmmss'}}
+            vendor=FluentDo <https://fluent.do>
+            maintainer=FluentDo <info@fluent.do>
+            name=FluentDo Agent
+            description=FluentDo Agent is a stable, secure by default, OSS (Apache-licensed) downstream distribution of Fluent Bit with predictable releases and long-term supported versions for 24 months.
 
       - name: Build and push by digest the standard ${{ matrix.target }} image
         id: production

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -147,6 +147,8 @@ jobs:
     needs:
       - test-kubernetes
       - test-container-config
+      # Sometimes skipped so we do not wait for it, if it fails will be caught higher up
+      # - test-redhat-certification
     steps:
       - name: All tests passed
         run: echo "All tests passed for ${{ inputs.image }}:${{ inputs.image-tag }}"

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -90,8 +90,9 @@ jobs:
 
       - name: Set up preflight binary
         run: |
-          curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
+          curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/latest/download/preflight-linux-amd64
           chmod a+x ./preflight-linux-amd64
+          ./preflight-linux-amd64 -v
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -98,6 +98,20 @@ jobs:
         run: ./preflight-linux-amd64 check container ${{ inputs.image }}:${{ inputs.image-tag }}
         shell: bash
 
+      # https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/1235
+      # https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/535
+      - name: Ensure we pass as preflight does not use error code exit
+        run: |
+          if grep 'Preflight result: FAILED' preflight.log; then
+            echo "ERROR: failed checks"
+            exit 1
+          elif ! grep 'Preflight result: PASSED' preflight.log; then
+            echo "ERROR: checks did not pass"
+            exit 1
+          fi
+          echo "INFO: checks passed"
+        shell: bash
+
       - name: Preflight log
         continue-on-error: true
         run: cat preflight.log

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -52,6 +52,9 @@ jobs:
     env:
       IMAGE: ${{ inputs.image }}
       IMAGE_TAG: ${{ inputs.image-tag }}
+    permissions:
+      packages: read
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -69,6 +72,28 @@ jobs:
 
       - name: Run config tests
         run: ./testing/verify-config.sh
+        shell: bash
+
+  test-redhat-certification:
+    name: Test UBI container will pass certification
+    if: contains( inputs.image, 'ubi' )
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.github-token }}
+
+      - name: Set up preflight binary
+        run: curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
+        shell: bash
+
+      - name: Run tests
+        run: ./preflight-linux-amd64 check container ${{ inputs.image }}:${{ inputs.image-tag }}
         shell: bash
 
   test-kubernetes:

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -89,11 +89,23 @@ jobs:
           password: ${{ secrets.github-token }}
 
       - name: Set up preflight binary
-        run: curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
+        run: |
+          curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
+          chmod a+x ./preflight-linux-amd64
         shell: bash
 
       - name: Run tests
         run: ./preflight-linux-amd64 check container ${{ inputs.image }}:${{ inputs.image-tag }}
+        shell: bash
+
+      - name: Preflight log
+        continue-on-error: true
+        run: cat preflight.log
+        shell: bash
+
+      - name: Image debug
+        continue-on-error: true
+        run: docker inspect ${{ inputs.image }}:${{ inputs.image-tag }}
         shell: bash
 
   test-kubernetes:

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -105,7 +105,9 @@ jobs:
 
       - name: Image debug
         continue-on-error: true
-        run: docker inspect ${{ inputs.image }}:${{ inputs.image-tag }}
+        run: |
+          docker pull ${{ inputs.image }}:${{ inputs.image-tag }}
+          docker inspect ${{ inputs.image }}:${{ inputs.image-tag }}
         shell: bash
 
   test-kubernetes:

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -97,6 +97,12 @@ RUN [ -n "$MAKE_EXTRA_ARGS" ] && make ${MAKE_EXTRA_ARGS} || make -j "$(getconf _
 
 # The release image now
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS production
+
+# We need to override any base image labels
+LABEL vendor='FluentDo <https://fluent.do>'
+LABEL maintainer='FluentDo <info@fluent.do>'
+LABEL name='FluentDo Agent'
+
 # hadolint ignore=DL3041
 RUN microdnf update -y && microdnf install -y openssl libyaml && microdnf clean all
 


### PR DESCRIPTION
Added preflight check to ensure the UBI container image supports certification.
This identified failing labels because we never set any so it just inherits all the UBI (or distroless) base image labels.
Updated to push our own labels now.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-04 16:47:15 UTC

<h3>Summary</h3>
This review covers only the changes made since the last review, not the entire PR. The latest changes focus on improving the Red Hat container certification testing infrastructure in the CI pipeline.

The primary modification is an upgrade to the preflight binary download mechanism in the container testing workflow. The change moves from downloading a fixed version (1.14.1) to using the 'latest' release from the Red Hat OpenShift preflight project. This ensures the FluentDo Agent stays current with evolving Red Hat certification requirements while adding a version verification step to confirm the binary downloaded successfully.

The update also enhances the error handling logic for preflight certification checks. Since the preflight tool has known issues with exit codes (referenced in GitHub issues #1235 and #535), the implementation relies on parsing the output logs rather than exit codes to determine certification success or failure. The error handling checks for both explicit 'FAILED' results and missing 'PASSED' results to ensure comprehensive validation.

This change integrates well with the existing Red Hat certification support infrastructure that was established in earlier commits. The conditional execution ensures these checks only run for UBI container images, maintaining the focused scope of Red Hat certification while preserving the existing build processes for other container variants.

**PR Description Notes:**
- The PR description accurately describes the core purpose but doesn't mention the specific version upgrade changes in this latest commit
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|-----------|
| .github/workflows/call-test-containers.yaml | 4/5 | Enhanced preflight binary download to use latest version with verification and improved error handling for certification checks |

</details>
<h3>Confidence score: 4/5</h3>

- This change is safe to merge with minimal risk as it improves the robustness of existing certification testing
- Score reflects good implementation practices with comprehensive error handling, though using 'latest' introduces some version stability concerns  
- Pay close attention to the preflight error handling logic to ensure it properly catches all failure scenarios

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->