### PR TITLE
fix: disable in-exec for distroless containers

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -73,6 +73,9 @@ WORKDIR /source/build/
 ARG CMAKE_EXTRA_ARGS
 ENV CMAKE_EXTRA_ARGS=${CMAKE_EXTRA_ARGS}
 
+# -DFLB_IN_EXEC=Off is to ensure in-exec is disabled for distroless containers without a shell
+# https://github.com/fluent/fluent-bit/issues/1758
+
 # We do not want word splitting for CMAKE_EXTRA_ARGS in case multiple are defined
 # hadolint ignore=SC2086
 RUN cmake -DCMAKE_BUILD_TYPE=Release \
@@ -83,6 +86,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release \
     -DFLUENTDO_AGENT_VERSION="$FLUENTDO_AGENT_VERSION" \
     -DFLB_LOG_NO_CONTROL_CHARS=On \
     -DFLB_CORO_STACK_SIZE=131072 \
+    -DFLB_IN_EXEC=Off \
     ${CMAKE_EXTRA_ARGS} \
     ..
 


### PR DESCRIPTION
Disable `in-exec` plugin to resolve #49 as distroless containers cannot support it - any image without `/bin/sh` will just silently fail if you try to invoke it rather than error out. This means folks may think it's working but it is not.

```shell
$ docker run --rm -it ghcr.io/fluentdo/agent/ubi:pr-50 --help|grep -i exec
  exec                    Exec Input
$ docker run --rm -it ghcr.io/fluentdo/agent/debian:pr-50 --help|grep -i exec
$ 
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-12 10:18:50 UTC

### Greptile Summary

This PR disables the `in-exec` plugin for Fluent Bit builds in Debian-based containers to address a critical issue with distroless containers. The change adds the CMake flag `-DFLB_IN_EXEC=Off` to prevent the exec plugin from being built into the binary. The problem occurs because distroless containers (like `gcr.io/distroless/cc-debian12` used in production) don't include `/bin/sh`, causing the exec plugin to fail silently without error messages. Users would think their exec configurations are working when they're actually not functioning. By disabling the plugin at build time, the system will provide clear feedback that the feature is unavailable rather than misleading users with silent failures. This change affects the Dockerfile.debian build configuration and ensures consistency across all image variants built from this file.

PR Description Notes:
- Minor grammatical improvement could be made: "distroless containers cannot support it" could be "distroless containers do not support it"

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile.debian | 5/5 | Adds CMake flag to disable in-exec plugin with proper documentation explaining the rationale for distroless container compatibility |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a well-documented, targeted fix addressing a specific compatibility issue with clear justification and proper implementation
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Docker Build" as Build
    participant "Multi-arch QEMU" as QEMU
    participant "Base Builder" as BaseBuilder
    participant "Source Builder" as SourceBuilder
    participant "Builder" as Builder
    participant "Deb Extractor" as DebExtractor
    participant "Production Image" as Production
    participant "Debug Image" as Debug

    User->>Build: "docker build"
    Build->>QEMU: "Copy QEMU static binaries for cross-arch"
    QEMU-->>Build: "ARM32 and ARM64 QEMU binaries"
    
    Build->>BaseBuilder: "Create base Debian builder with dependencies"
    BaseBuilder->>BaseBuilder: "Install build tools, SSL, curl, systemd libs"
    
    Build->>SourceBuilder: "Prepare source code and directories"
    SourceBuilder->>SourceBuilder: "Initialize git repo for build"
    SourceBuilder->>SourceBuilder: "Copy source files and configs"
    
    Build->>Builder: "Configure and build Fluent Bit"
    Builder->>Builder: "Run cmake with -DFLB_IN_EXEC=Off"
    Builder->>Builder: "Compile and strip binary"
    Builder->>Builder: "Generate schema.json"
    
    Build->>DebExtractor: "Extract Debian packages for distroless"
    DebExtractor->>DebExtractor: "Download runtime dependencies"
    DebExtractor->>DebExtractor: "Extract .deb packages to /dpkg"
    
    Build->>Production: "Create distroless production image"
    Production->>Production: "Copy libraries from extractor"
    Production->>Production: "Copy certificates and binaries"
    
    Build->>Debug: "Create debug image with dev tools"
    Debug->>Debug: "Install debugging and networking tools"
    Debug->>Debug: "Copy production artifacts"
    
    Build-->>User: "Multi-stage build complete with production and debug images"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->