### PR TITLE
fix: resolve failure in Red Hat publishing

### DIFF
--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -70,6 +70,12 @@ jobs:
             packages: read
             # Required for GCP secrets access
             id-token: write
+        env:
+          # We must match up the official image we have used for publishing upstream
+          RHEL_SOURCE_IMAGE: ghcr.io/fluentdo/agent
+        needs:
+          # We must use the top-level image here - see above
+          - promote-ghcr-images
         steps:
             - name: Log in to the Container registry
               uses: docker/login-action@v3
@@ -105,5 +111,5 @@ jobs:
                 ./preflight-linux-amd64 check container \
                     --certification-component-id 68e14199529ca9e0c382582c \
                     --pyxis-api-token '${{ steps.get-secrets.outputs.redhat-api-key }}' \
-                    --submit $UBI_IMAGE_NAME:${{ inputs.version }}
+                    --submit $RHEL_SOURCE_IMAGE:${{ inputs.version }}
               shell: bash


### PR DESCRIPTION
For Red Hat publishing we need to make sure we use our top-level `ghcr.io/fluentdo/agent` and not the `ghcr.io/fluentdo/agent/ubi` one it comes from as this is what we have set up in our product listing.

Otherwise we fail to publish with an error: https://github.com/FluentDo/agent/actions/runs/18631014362/job/53115791948

```bash
./preflight-linux-amd64 check container \
      --certification-component-id 68e14199529ca9e0c382582c \
      --pyxis-api-token '***' \
      --submit ghcr.io/fluentdo/agent/ubi:25.10.3
...
Error: could not submit to pyxis: could not update project: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "The 'container.repository' field is immutable for projects if the project is associated with at least one published image.", "status": 400, "trace_id": "0x493aff54e060c4035d6492d6e739a8c4"}
2025/10/19 13:24:02 could not submit to pyxis: could not update project: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "The 'container.repository' field is immutable for projects if the project is associated with at least one published image.", "status": 400, "trace_id": "0x493aff54e060c4035d6492d6e739a8c4"}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 11:35:08 UTC

<h3>Greptile Summary</h3>


This PR fixes Red Hat catalog publishing by ensuring the `preflight` tool submits the correct container repository path. The change switches from using `$UBI_IMAGE_NAME` (`ghcr.io/fluentdo/agent/ubi`) to `$RHEL_SOURCE_IMAGE` (`ghcr.io/fluentdo/agent`) to match the immutable repository field in the Red Hat product listing.

**Key Changes:**
- Added new environment variable `RHEL_SOURCE_IMAGE` set to `ghcr.io/fluentdo/agent`
- Added `needs: promote-ghcr-images` dependency to ensure top-level image exists before Red Hat submission
- Changed preflight submission from `$UBI_IMAGE_NAME:${{ inputs.version }}` to `$RHEL_SOURCE_IMAGE:${{ inputs.version }}`

**Why This Matters:**
Red Hat's API rejects attempts to change the `container.repository` field once an image has been published. The previous workflow was trying to submit `ghcr.io/fluentdo/agent/ubi` but the product listing was configured for `ghcr.io/fluentdo/agent`, causing a 400 error. This fix ensures the correct repository path is used, allowing successful certification and publishing.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is straightforward and directly addresses a documented API error. The fix correctly uses the top-level image that's already being promoted in the same workflow, adds appropriate job dependencies to ensure ordering, and aligns with Red Hat's immutable repository field requirements.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/call-publish-release-images.yaml | 5/5 | Changed Red Hat submission to use top-level `ghcr.io/fluentdo/agent` instead of `ghcr.io/fluentdo/agent/ubi`, added dependency on promote-ghcr-images job |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Workflow as GitHub Workflow
    participant GHCR_UBI as ghcr.io/fluentdo/agent/ubi
    participant GHCR_Debian as ghcr.io/fluentdo/agent/debian
    participant GHCR_Top as ghcr.io/fluentdo/agent
    participant Preflight as Red Hat Preflight Tool
    participant RedHat as Red Hat Catalog API

    Note over Workflow: Job: promote-ghcr-images
    Workflow->>GHCR_UBI: Pull UBI image with tag
    Workflow->>GHCR_Top: Promote UBI image via skopeo copy
    Workflow->>GHCR_Debian: Pull Debian image with tag
    Workflow->>GHCR_Top: Promote Debian image as -slim via skopeo copy
    
    Note over Workflow: Job: promote-redhat-catalog-images<br/>(needs: promote-ghcr-images)
    Workflow->>GHCR_Top: Login to container registry
    Workflow->>Preflight: Download and setup preflight tool
    Workflow->>Preflight: Run preflight check container
    Note over Preflight: Submitting ghcr.io/fluentdo/agent:version<br/>(RHEL_SOURCE_IMAGE)
    Preflight->>RedHat: Submit for certification<br/>component-id: 68e14199529ca9e0c382582c
    RedHat-->>Preflight: Success (repository matches product listing)
    Preflight-->>Workflow: Certification complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->