### PR TITLE
ci: replace manual `preflight` tool installation with `openshift-tools-installer`

### DIFF
--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -85,11 +85,10 @@ jobs:
                   password: ${{ secrets.github-token }}
 
             - name: Set up preflight binary
-              run: |
-                  curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/latest/download/preflight-linux-amd64
-                  chmod a+x ./preflight-linux-amd64
-                  ./preflight-linux-amd64 -v
-              shell: bash
+              uses: redhat-actions/openshift-tools-installer@v1
+              with:
+                preflight: latest
+                source: github
 
             - name: Authenticate with GCP
               uses: google-github-actions/auth@v3
@@ -108,7 +107,7 @@ jobs:
 
             - name: Submit container to Red Hat for certification
               run: |
-                ./preflight-linux-amd64 check container \
+                preflight check container \
                     --certification-component-id 68e14199529ca9e0c382582c \
                     --pyxis-api-token '${{ steps.get-secrets.outputs.redhat-api-key }}' \
                     --submit $RHEL_SOURCE_IMAGE:${{ inputs.version }}

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -144,14 +144,13 @@ jobs:
           password: ${{ secrets.github-token }}
 
       - name: Set up preflight binary
-        run: |
-          curl -sSfLO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/latest/download/preflight-linux-amd64
-          chmod a+x ./preflight-linux-amd64
-          ./preflight-linux-amd64 -v
-        shell: bash
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          preflight: latest
+          source: github
 
       - name: Run tests
-        run: ./preflight-linux-amd64 check container ${{ inputs.image }}:${{ inputs.image-tag }}
+        run: preflight check container ${{ inputs.image }}:${{ inputs.image-tag }}
         shell: bash
 
       # https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/1235


### PR DESCRIPTION
The CI workflows manually download & install the `preflight` tool from a specific URL.

RedHat offer a [`openshift-tools-installer` action](https://github.com/redhat-actions/openshift-tools-installer) to abstract this away.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 15:48:19 UTC

<h3>Greptile Summary</h3>


This PR modernizes the CI workflows by replacing manual `preflight` tool installation with Red Hat's official `openshift-tools-installer` action.

- Replaced manual curl-based download and installation of `preflight-linux-amd64` with `redhat-actions/openshift-tools-installer@v1`
- Updated binary invocation from `./preflight-linux-amd64` to `preflight` (now available in PATH)
- Applied consistently across both publish and test workflows
- Simplifies maintenance by leveraging Red Hat's official action for tool management

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - clean refactoring that improves maintainability without functional changes
- The changes are straightforward and improve code quality by using an official Red Hat action instead of manual installation. The action handles download, installation, and PATH configuration automatically. Both workflows are updated consistently, and the functionality remains identical.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/call-publish-release-images.yaml | 5/5 | Replaced manual `preflight` installation with `redhat-actions/openshift-tools-installer@v1` action and updated binary invocation from `./preflight-linux-amd64` to `preflight` |
| .github/workflows/call-test-containers.yaml | 5/5 | Replaced manual `preflight` installation with `redhat-actions/openshift-tools-installer@v1` action and updated binary invocation from `./preflight-linux-amd64` to `preflight` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Workflow
    participant Installer as openshift-tools-installer Action
    participant GitHub as GitHub Releases
    participant Preflight as Preflight Binary
    participant RedHat as Red Hat Certification API

    Note over GH: call-publish-release-images.yaml
    GH->>Installer: Request preflight: latest
    Installer->>GitHub: Download preflight binary
    GitHub-->>Installer: Return preflight-linux-amd64
    Installer->>Installer: Install & add to PATH
    Installer-->>GH: Tool ready
    GH->>Preflight: preflight check container
    Preflight->>RedHat: Submit certification request
    RedHat-->>Preflight: Certification result
    Preflight-->>GH: Check complete

    Note over GH: call-test-containers.yaml
    GH->>Installer: Request preflight: latest
    Installer->>GitHub: Download preflight binary
    GitHub-->>Installer: Return preflight-linux-amd64
    Installer->>Installer: Install & add to PATH
    Installer-->>GH: Tool ready
    GH->>Preflight: preflight check container
    Preflight-->>GH: Validation result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->