### PR TITLE
ci: remove delay for unit test failures

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,6 +66,7 @@ jobs:
             perf
             refactor
             test
+            backport
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           # scopes: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -169,12 +169,12 @@ jobs:
                       source/build/coveralls.json
                   if-no-files-found: error
 
-            - name: Breakpoint if tests failed
-              if: failure() && contains(runner.name, 'nsc-')
-              uses: namespacelabs/breakpoint-action@v0
-              with:
-                  duration: 5m
-                  authorized-users: patrick-stephens,niedbalski
+            # - name: Breakpoint if tests failed
+            #   if: failure() && contains(runner.name, 'nsc-')
+            #   uses: namespacelabs/breakpoint-action@v0
+            #   with:
+            #       duration: 5m
+            #       authorized-users: patrick-stephens,niedbalski
 
     # Placeholder to make it simple to create a status check on this, do not change name.
     # Instead of modifying branch protection rules every time we add a new job, we just


### PR DESCRIPTION
Simple CI changes to remove waiting to debug unit tests on failure - adding 5 minutes to each run currently and unnecessary.
Also added a new `backport` PR type.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-01 16:51:13 UTC

<h3>Greptile Summary</h3>


Removed breakpoint debugging action from unit test workflow to eliminate unnecessary 5-minute delays on test failures, and added `backport` as a valid PR type for semantic commit validation.

**Key changes:**
- Commented out `namespacelabs/breakpoint-action@v0` step in `.github/workflows/unit-tests.yaml` (lines 172-177) to remove 5-minute debugging delay when tests fail
- Added `backport` to the list of allowed conventional commit types in `.github/workflows/lint.yaml` (line 69)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Both changes are trivial CI configuration updates: commenting out a debugging step and adding a new PR type to an allowed list. No functional code is affected, and the changes align perfectly with the stated goals of reducing unnecessary CI runtime and supporting backport PRs.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/unit-tests.yaml | 5/5 | Commented out breakpoint debugging action to remove 5-minute delay on test failures |
| .github/workflows/lint.yaml | 5/5 | Added `backport` as a valid PR type for conventional commits validation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub PR
    participant Lint as Lint Workflow
    participant Test as Unit Test Workflow
    
    Dev->>GH: Opens/Updates PR
    
    GH->>Lint: Triggers lint.yaml
    Lint->>Lint: Validate PR title format
    Note over Lint: Now accepts "backport" type
    Lint-->>GH: ✓ Validation passes
    
    GH->>Test: Triggers unit-tests.yaml
    Test->>Test: Run unit tests with sanitizers
    
    alt Tests Pass
        Test-->>GH: ✓ Tests complete
    else Tests Fail
        Test-->>GH: ✗ Tests failed
        Note over Test: Breakpoint debug removed<br/>(no 5min delay)
    end
    
    Test->>Test: Generate coverage reports
    Test->>GH: Upload artifacts
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->