### PR TITLE
ci: fix missing tags and add dry-run

### DIFF
--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -149,7 +149,8 @@ jobs:
           git tag ${{ steps.tag_name.outputs.tag_name }}
         shell: bash
 
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !github.event.inputs.dry-run) }}
+      - name: Push tag
+        if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
         run: |
           git push origin ${{ steps.tag_name.outputs.tag_name }}
         shell: bash


### PR DESCRIPTION
No builds carried out for this branch so unable to find SHA to check out.
Added dry-run support as well for testing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-03 10:26:56 UTC

<h3>Greptile Summary</h3>


This PR adds dry-run support and fixes issues with missing tags by adding `fallbackToEarliestSha: true` and `fetch-depth: 0`. The changes are well-structured and correct.

- Added `dry-run` workflow input (defaults to `true`) for safe testing without pushing tags
- Added `fallbackToEarliestSha: true` to handle branches without successful builds
- Added `fetch-depth: 0` to ensure full git history is available
- Split the create/push tag logic into two separate steps with proper conditional logic
- The conditional on line 153 correctly allows scheduled runs to push tags while respecting the dry-run flag for manual triggers

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The YAML syntax is valid with properly formatted steps, the conditional logic correctly handles both scheduled and manual runs, and all additions (dry-run input, fallbackToEarliestSha, fetch-depth) are appropriate and well-implemented
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/cron-auto-release.yaml | 5/5 | Added dry-run support, `fallbackToEarliestSha`, and `fetch-depth: 0` - all changes are correct and safe |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Trigger as Cron/Manual Trigger
    participant FindJob as find-last-good Job
    participant BuildAction as last-successful-build-action
    participant CreateJob as create-tag Job
    participant GCP as GCP Secret Manager
    participant Git as Git Repository
    
    Trigger->>FindJob: Start workflow (schedule or workflow_dispatch)
    FindJob->>FindJob: Detect branch (25.10-lts or main)
    FindJob->>BuildAction: Find last successful build SHA
    BuildAction->>BuildAction: Check with fallbackToEarliestSha=true
    BuildAction-->>FindJob: Return SHA (or earliest if none found)
    
    FindJob->>CreateJob: Pass SHA and branch
    CreateJob->>GCP: Authenticate and get GitHub PAT
    GCP-->>CreateJob: Return PAT token
    CreateJob->>Git: Checkout SHA (fetch-depth: 0, fetch-tags: true)
    CreateJob->>CreateJob: Generate tag name
    CreateJob->>Git: Check if tag exists
    CreateJob->>CreateJob: Create tag locally
    
    alt Schedule event OR (Manual dispatch AND dry-run=false)
        CreateJob->>Git: Push tag to origin
        Git-->>CreateJob: Tag pushed successfully
    else Manual dispatch with dry-run=true
        CreateJob->>CreateJob: Skip push (dry-run mode)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->