### PR TITLE
backport: disable test failures and fix auto-release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -256,6 +256,8 @@ jobs:
         with:
           # Add any jobs that can be skipped here to avoid failure of this job
           allowed-skips: build-linux,build-windows,build-macos,test-packages
+          # TODO: remove once failures are resolved to ensure auto-release job still goes ahead with latest commit
+          allowed-failures: test-packages
           # Convert the needs object to JSON to pass it in
           jobs: ${{ toJSON(needs) }}
       - name: All tests complete

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         default: "main"
         type: string
+      dry-run:
+        description: Dry-run the change by doing everything except pushing the tag
+        required: false
+        default: true
+        type: boolean
 jobs:
   find-last-good:
     runs-on: ubuntu-latest
@@ -60,6 +65,7 @@ jobs:
           branch: ${{ steps.detect-branch.outputs.branch || 'main' }}
           workflow: "Build and test"
           verify: true
+          fallbackToEarliestSha: true
 
   create-tag:
     name: Create tag for ${{ needs.find-last-good.outputs.branch }}
@@ -94,6 +100,8 @@ jobs:
           token: ${{ steps.get-secrets.outputs.github-pat }}
           # We need tags present to check for them
           fetch-tags: true
+          # Need full history
+          fetch-depth: 0
 
       - name: Tag name
         id: tag_name
@@ -139,5 +147,11 @@ jobs:
       - name: Create tag
         run: |
           git tag ${{ steps.tag_name.outputs.tag_name }}
+        shell: bash
+
+      - name: Push tag
+        if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
+        run: |
           git push origin ${{ steps.tag_name.outputs.tag_name }}
         shell: bash
+


### PR DESCRIPTION
Backport of workflow changes from `main`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-03 10:43:35 UTC

<h3>Greptile Summary</h3>


Backports workflow improvements from `main` to the `release/25.10-lts` branch. The changes focus on making the auto-release process more robust and testable.

**Key changes:**
- **build.yaml**: Allows `test-packages` job to fail without blocking the `tests-complete` job, ensuring auto-release proceeds even if package tests fail (aligns with custom rule `da871e3f-160e-4a45-ba5e-f1b6fbac516a`)
- **cron-auto-release.yaml**: Adds `dry-run` input parameter for testing tag creation without pushing, enables `fallbackToEarliestSha` for more resilient commit lookup, adds full git history fetch (`fetch-depth: 0`), and separates tag creation from tag pushing into distinct steps

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it implements defensive workflow improvements aligned with project policies
- Score reflects well-tested backport changes that improve reliability. The `allowed-failures` addition is explicitly documented with a TODO and aligns with custom instructions about preventing package failures from blocking releases. The dry-run feature and improved git history handling reduce the risk of accidentally creating incorrect tags. Minor concern is the temporary nature of allowing test failures.
- No files require special attention - both changes are defensive improvements to existing workflows

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/build.yaml | 4/5 | Added `allowed-failures: test-packages` to permit test failures while still marking build as successful for auto-release |
| .github/workflows/cron-auto-release.yaml | 5/5 | Added `dry-run` input parameter, `fallbackToEarliestSha: true`, full git history fetch, and conditional tag push logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Cron Schedule/Manual Trigger
    participant FindLastGood as find-last-good Job
    participant GH as GitHub API
    participant CreateTag as create-tag Job
    participant Build as Build Workflow
    
    Cron->>FindLastGood: Trigger (schedule/workflow_dispatch)
    FindLastGood->>GH: Query last successful build
    Note over FindLastGood,GH: Uses fallbackToEarliestSha: true
    GH-->>FindLastGood: Return SHA + branch
    FindLastGood->>CreateTag: Pass SHA and branch
    
    CreateTag->>CreateTag: Checkout with fetch-depth: 0
    CreateTag->>CreateTag: Generate tag name
    CreateTag->>CreateTag: Check if tag exists
    CreateTag->>CreateTag: Create tag locally
    
    alt Not dry-run
        CreateTag->>GH: Push tag to origin
        GH->>Build: Trigger build workflow
        Note over Build: tests-complete allows test-packages to fail
    else Dry-run (workflow_dispatch with dry-run=true)
        CreateTag->>CreateTag: Skip push (dry-run mode)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->