### PR TITLE
ci: disable testing packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -247,7 +247,9 @@ jobs:
       - build-macos
       - build-image
       - test-containers
-      - test-packages
+      # TODO: remove once failures are resolved to ensure auto-release job still goes ahead with latest commit
+      # https://github.com/FluentDo/agent/issues/73
+      # - test-packages
       # Add additional jobs here as required that must complete
     runs-on: ubuntu-latest
     steps:
@@ -256,8 +258,6 @@ jobs:
         with:
           # Add any jobs that can be skipped here to avoid failure of this job
           allowed-skips: build-linux,build-windows,build-macos,test-packages
-          # TODO: remove once failures are resolved to ensure auto-release job still goes ahead with latest commit
-          allowed-failures: test-packages
           # Convert the needs object to JSON to pass it in
           jobs: ${{ toJSON(needs) }}
       - name: All tests complete

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -64,6 +64,10 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
           branch: ${{ steps.detect-branch.outputs.branch || 'main' }}
           workflow: "Build and test"
+          # Ignore other failures in the workflow, only want test output for now
+          # TODO: remove once failures are resolved in package testing
+          # https://github.com/FluentDo/agent/issues/73
+          job: "All tests complete"
           verify: true
           fallbackToEarliestSha: true
 


### PR DESCRIPTION
Even with the allowed-failures option from #89 we are still seeing a failure: https://github.com/FluentDo/agent/actions/runs/19031925566/job/54350908154

Update to only check the specific job for auto-release and ensure we do not make testing packages a required dependency.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-03 11:47:36 UTC

<h3>Greptile Summary</h3>


Resolves auto-release workflow failures by decoupling package testing from release process. The changes prevent `test-packages` job failures from blocking the `tests-complete` status check, which the cron auto-release job now specifically targets.

**Key changes:**
- **`.github/workflows/build.yaml`**: Commented out `test-packages` from `tests-complete` job dependencies and removed the `allowed-failures` parameter (aligns with custom rule `da871e3f-160e-4a45-ba5e-f1b6fbac516a`)
- **`.github/workflows/cron-auto-release.yaml`**: Added `job: "All tests complete"` parameter to check only the specific status job rather than the entire workflow

The solution is more robust than the previous approach in #89 which used `allowed-failures`. By completely removing the dependency, the workflow guarantees the `tests-complete` job will succeed regardless of package test status.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it implements a defensive workflow improvement that prevents package test failures from blocking releases
- The changes are minimal, well-documented with TODO comments referencing issue #73, and follow the project's custom rule for handling build dependencies. The solution is superior to the previous `allowed-failures` approach as it completely decouples package testing from the release gate. Both TODO comments include proper issue references and the changes are consistent across both files.
- No files require special attention - both changes are straightforward workflow improvements

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/build.yaml | 5/5 | Removed `test-packages` from `tests-complete` dependencies and eliminated `allowed-failures` parameter to prevent package test failures from blocking auto-release |
| .github/workflows/cron-auto-release.yaml | 5/5 | Added `job: "All tests complete"` parameter to target specific job status check instead of entire workflow, ensuring auto-release only verifies the core test completion job |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Cron Auto-Release
    participant Action as last-successful-build-action
    participant Workflow as Build and Test Workflow
    participant TestsComplete as tests-complete Job
    participant TestPackages as test-packages Job
    
    Cron->>Action: Find last successful build
    Note over Action: job: "All tests complete"<br/>fallbackToEarliestSha: true
    Action->>Workflow: Query for successful runs
    Workflow->>TestsComplete: Check job status
    Note over TestsComplete: Depends on:<br/>- build-linux<br/>- build-windows<br/>- build-macos<br/>- build-image<br/>- test-containers<br/>(test-packages removed)
    TestsComplete->>TestsComplete: allowed-skips includes test-packages
    Note over TestPackages: May fail, but doesn't block
    TestsComplete-->>Workflow: Success (regardless of test-packages)
    Workflow-->>Action: Return successful SHA
    Action-->>Cron: SHA for tagging
    Cron->>Cron: Create and push tag
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->