### PR TITLE
docs: fix links

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,7 +61,7 @@ The CI/CD pipeline is designed to:
 
 ### Build and Test
 
-**File:** [`.github/workflows/build.yaml`](.github/workflows/build.yaml)
+**File:** [`.github/workflows/build.yaml`](./build.yaml)
 
 **Triggers:**
 
@@ -106,7 +106,7 @@ The CI/CD pipeline is designed to:
 
 ### Unit Tests
 
-**File:** [`.github/workflows/unit-tests.yaml`](.github/workflows/unit-tests.yaml)
+**File:** [`.github/workflows/unit-tests.yaml`](./unit-tests.yaml)
 
 **Triggers:**
 
@@ -135,7 +135,7 @@ The CI/CD pipeline is designed to:
 
 ### Lint
 
-**File:** [`.github/workflows/lint.yaml`](.github/workflows/lint.yaml)
+**File:** [`.github/workflows/lint.yaml`](./lint.yaml)
 
 **Triggers:**
 
@@ -161,7 +161,7 @@ The CI/CD pipeline is designed to:
 
 ### Lint Packages
 
-**File:** [`.github/workflows/lint-packages.yaml`](.github/workflows/lint-packages.yaml)
+**File:** [`.github/workflows/lint-packages.yaml`](./lint-packages.yaml)
 
 **Triggers:**
 
@@ -184,7 +184,7 @@ The CI/CD pipeline is designed to:
 
 ### Test Specific Versions
 
-**File:** [`.github/workflows/test.yaml`](.github/workflows/test.yaml)
+**File:** [`.github/workflows/test.yaml`](./test.yaml)
 
 **Triggers:**
 
@@ -207,7 +207,7 @@ The CI/CD pipeline is designed to:
 
 ### Auto Release
 
-**File:** [`.github/workflows/cron-auto-release.yaml`](.github/workflows/cron-auto-release.yaml)
+**File:** [`.github/workflows/cron-auto-release.yaml`](./cron-auto-release.yaml)
 
 **Triggers:**
 
@@ -238,7 +238,7 @@ The CI/CD pipeline is designed to:
 
 ### Update Version
 
-**File:** [`.github/workflows/update-version.yaml`](.github/workflows/update-version.yaml)
+**File:** [`.github/workflows/update-version.yaml`](./update-version.yaml)
 
 **Triggers:**
 
@@ -268,7 +268,7 @@ The CI/CD pipeline is designed to:
 
 ### Build Containers
 
-**File:** [`.github/workflows/call-build-containers.yaml`](.github/workflows/call-build-containers.yaml)
+**File:** [`.github/workflows/call-build-containers.yaml`](./call-build-containers.yaml)
 
 **Purpose:** Builds multi-architecture container images with signing.
 
@@ -310,7 +310,7 @@ The CI/CD pipeline is designed to:
 
 ### Build Linux Packages
 
-**File:** [`.github/workflows/call-build-linux-packages.yaml`](.github/workflows/call-build-linux-packages.yaml)
+**File:** [`.github/workflows/call-build-linux-packages.yaml`](./call-build-linux-packages.yaml)
 
 **Purpose:** Builds Linux packages (DEB, RPM) for multiple distributions.
 
@@ -356,7 +356,7 @@ The CI/CD pipeline is designed to:
 
 ### Build Windows Packages
 
-**File:** [`.github/workflows/call-build-windows-packages.yaml`](.github/workflows/call-build-windows-packages.yaml)
+**File:** [`.github/workflows/call-build-windows-packages.yaml`](./call-build-windows-packages.yaml)
 
 **Purpose:** Builds Windows packages (EXE, MSI, ZIP).
 
@@ -388,7 +388,7 @@ The CI/CD pipeline is designed to:
 
 ### Build macOS Packages
 
-**File:** [`.github/workflows/call-build-macos-packages.yaml`](.github/workflows/call-build-macos-packages.yaml)
+**File:** [`.github/workflows/call-build-macos-packages.yaml`](./call-build-macos-packages.yaml)
 
 **Purpose:** Builds macOS packages (PKG) for Intel and Apple Silicon.
 
@@ -424,7 +424,7 @@ The CI/CD pipeline is designed to:
 
 ### Test Containers
 
-**File:** [`.github/workflows/call-test-containers.yaml`](.github/workflows/call-test-containers.yaml)
+**File:** [`.github/workflows/call-test-containers.yaml`](./call-test-containers.yaml)
 
 **Purpose:** Comprehensive container testing including BATS, Kubernetes, and certification.
 
@@ -458,7 +458,7 @@ The CI/CD pipeline is designed to:
 
 ### Test Containers on Kubernetes
 
-**File:** [`.github/workflows/call-test-containers-k8s.yaml`](.github/workflows/call-test-containers-k8s.yaml)
+**File:** [`.github/workflows/call-test-containers-k8s.yaml`](./call-test-containers-k8s.yaml)
 
 **Purpose:** Tests container images on Kubernetes clusters.
 
@@ -488,7 +488,7 @@ The CI/CD pipeline is designed to:
 
 ### Test Packages
 
-**File:** [`.github/workflows/call-test-packages.yaml`](.github/workflows/call-test-packages.yaml)
+**File:** [`.github/workflows/call-test-packages.yaml`](./call-test-packages.yaml)
 
 **Purpose:** Tests Linux packages on target distributions.
 
@@ -527,7 +527,7 @@ The CI/CD pipeline is designed to:
 
 ### Publish Release Images
 
-**File:** [`.github/workflows/call-publish-release-images.yaml`](.github/workflows/call-publish-release-images.yaml)
+**File:** [`.github/workflows/call-publish-release-images.yaml`](./call-publish-release-images.yaml)
 
 **Purpose:** Promotes release images to production registries.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cmake ..
 make
 ```
 
-[Refer to the CI](./.github/README.md) for full examples of different target builds:
+[Refer to the CI](./.github/workflows/README.md) for full examples of different target builds:
 
 - [Container builds](./.github/workflows/call-build-containers.yaml)
 - [Linux builds](./.github/workflows/call-build-linux-packages.yaml)


### PR DESCRIPTION
Moved README.md out of .github/ as that is picked up by default and corrected workflow links as well.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-04 14:16:23 UTC

<h3>Greptile Summary</h3>


Fixed documentation links to use correct paths. The README.md CI reference link was updated to point to `./.github/workflows/README.md`, and all workflow file links within the workflows README were corrected from absolute paths (`.github/workflows/*.yaml`) to relative paths (`./*.yaml`) since the README is located in the same directory as the workflow files.

- Updated CI reference link in root `README.md:137` from `./.github/README.md` to `./.github/workflows/README.md`
- Corrected 15 workflow file links in `.github/workflows/README.md` to use relative paths instead of absolute paths

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - only documentation link fixes
- All changes are limited to markdown documentation links with no code modifications. The links were verified to be correct - relative paths work since the README is in the same directory as the workflow files it references.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Fixed CI documentation link to point to the correct path `./.github/workflows/README.md` |
| .github/workflows/README.md | 5/5 | Updated all workflow file links from absolute paths to relative paths (e.g., `.github/workflows/build.yaml` → `./build.yaml`) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Repo as Repository
    participant RootREADME as README.md
    participant WorkflowREADME as .github/workflows/README.md
    participant Workflows as Workflow Files
    
    Dev->>Repo: Move README.md from .github/ to root
    Dev->>RootREADME: Update CI link reference
    RootREADME-->>WorkflowREADME: Link to ./.github/workflows/README.md
    
    Dev->>WorkflowREADME: Fix 15 workflow file links
    WorkflowREADME-->>Workflows: Use relative paths (./build.yaml, etc)
    
    Note over WorkflowREADME,Workflows: Links now work correctly since README<br/>is in same directory as workflow files
    
    WorkflowREADME->>Workflows: ./build.yaml
    WorkflowREADME->>Workflows: ./unit-tests.yaml
    WorkflowREADME->>Workflows: ./lint.yaml
    WorkflowREADME->>Workflows: ./call-build-containers.yaml
    WorkflowREADME->>Workflows: ... (11 more workflow files)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->