### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -44,7 +44,7 @@ jobs:
               run: |
                   brew update
                   # We ignore errors here as some packages may already be installed
-                  brew install bison flex gnu-sed libyaml openssl pkgconfig libgit2 cyrus-sasl rocksdb || true
+                  brew install bison flex gnu-sed libyaml openssl pkgconfig libgit2 cyrus-sasl rocksdb libtool || true
                   # Remove dynamic linkage for libyaml
                   rm -fv $(brew --prefix libyaml)/lib/*.dylib
                   # Remove dynamic linkage for zstd added by curl install
@@ -95,12 +95,6 @@ jobs:
               run: |
                   DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 DYLD_PRINT_RPATHS=1 bin/fluentdo-agent --dry-run
               working-directory: source/build
-
-            - name: Check config
-              run: testing/verify-config.sh
-              env:
-                  FLUENT_BIT_BINARY: ${{ github.workspace }}/source/build/bin/fluentdo-agent
-              shell: bash
 
             - name: Upload build packages
               uses: actions/upload-artifact@v5

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -115,6 +115,12 @@ jobs:
           C:\vcpkg\vcpkg install --recurse libgit2 --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
 
+      # Unfortunately static builds are not supported and trigger link errors
+      # - name: Build libsasl with vcpkg
+      #   run: |
+      #     C:\vcpkg\vcpkg install --recurse cyrus-sasl --allow-unsupported --triplet ${{ matrix.config.vcpkg_triplet }}
+      #   shell: cmd
+
       - name: Upgrade any outdated vcpkg packages
         run: |
           C:\vcpkg\vcpkg upgrade --no-dry-run


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/FluentDo/agent/actions/runs/19174184656
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 16:17:25 UTC

<h3>Greptile Summary</h3>


Synchronizes workflow configurations from main branch to the release/25.10-lts branch, making two key adjustments for release stability:
- Adds `libtool` as a build dependency for macOS packages
- Removes the config verification step from macOS builds to prevent blocking releases on test failures
- Documents libsasl static build limitation for Windows with a commented-out build step

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minimal risk - these are routine workflow maintenance changes
- Score reflects standard CI/CD configuration updates for a release branch. The addition of `libtool` is a low-risk dependency addition. Removal of the config check step aligns with custom rules to prevent release blocking, though it does reduce verification. The Windows libsasl change is documentation-only.
- `.github/workflows/call-build-macos-packages.yaml` - verify that removing the config check doesn't compromise release quality

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/call-build-macos-packages.yaml | 4/5 | Added `libtool` dependency and removed config verification step to prevent release blocking |
| .github/workflows/call-build-windows-packages.yaml | 5/5 | Added commented-out libsasl build with clear explanation about static build limitations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant macOS as macOS Build Job
    participant Windows as Windows Build Job
    participant Brew as Homebrew
    participant vcpkg as vcpkg Package Manager
    participant Artifacts as Artifacts Storage

    Note over GHA: Workflow triggered on release/25.10-lts
    
    par macOS Build
        GHA->>macOS: Start build job
        macOS->>Brew: brew update
        macOS->>Brew: Install dependencies (bison, flex, libtool, etc.)
        Note over macOS,Brew: Added libtool dependency
        macOS->>macOS: Remove dynamic libraries (.dylib)
        macOS->>macOS: Setup version from tag
        macOS->>macOS: Build with cmake
        Note over macOS: Config check step removed
        macOS->>macOS: Check linkage (continue-on-error)
        macOS->>Artifacts: Upload .pkg packages
    and Windows Build
        GHA->>Windows: Start build job
        Windows->>Windows: Install winflexbison, cmake, nsis
        Windows->>vcpkg: Install openssl (static)
        Windows->>vcpkg: Install libyaml (static)
        Windows->>vcpkg: Install libgit2 (static)
        Note over Windows,vcpkg: libsasl commented out (static not supported)
        Windows->>vcpkg: Upgrade packages
        Windows->>Windows: Build with cmake NMake
        Windows->>Artifacts: Upload .exe/.msi/.zip packages
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->