### PR TITLE
fix: resolve upload failures

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -149,10 +149,7 @@ jobs:
         if: matrix.config.name == 'coverage'
         uses: coverallsapp/github-action@v2
         with:
-          files: |
-            source/build/coverage*.*
-            source/build/cobertura.xml
-            source/build/coveralls.json
+          file: source/build/coveralls.json
 
       - name: Upload coverage reports
         if: matrix.config.name == 'coverage'


### PR DESCRIPTION
Flagged in #130 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Coveralls uploads in CI by sending only source/build/coveralls.json to the Coveralls action, ensuring reliable coverage reporting.

- **Bug Fixes**
  - Use the Coveralls action’s single file input (file: source/build/coveralls.json) instead of multiple file globs.

<sup>Written for commit 3ac95e46a2f9645c37a2ecb60fa800a9f6bec984. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

