### PR TITLE
fix: resolve gcov failures

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -135,11 +135,9 @@ jobs:
         working-directory: source/build
         run: |
           gcovr --object-directory . --root .. --gcov-ignore-parse-errors --gcov-ignore-errors \
-            --exclude 'sql-parser.l' \
             --sort uncovered-percent \
             --xml=cobertura.xml \
             --html=coverage.html --html-title='FluentDo Agent Test Coverage Report' \
-            --coveralls=coveralls.json \
             --json=coverage.json \
             --txt=coverage.txt \
             --print-summary
@@ -151,7 +149,9 @@ jobs:
         if: matrix.config.name == 'coverage'
         uses: coverallsapp/github-action@v2
         with:
-          file: source/build/coveralls.json
+          file: source/build/cobertura.xml
+          format: cobertura
+          flag-name: Unit
 
       - name: Upload coverage reports
         if: matrix.config.name == 'coverage'


### PR DESCRIPTION
Resolve failures seen during coverage generation









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix coverage generation in the unit-tests workflow by disabling matrix fail-fast, updating gcovr to use --sort uncovered-percent, and uploading Coveralls using Cobertura output. CI no longer fails on gcovr, and Cobertura and HTML reports are generated as expected.

Risk: 5

<sup>Written for commit 154ae2e3fb080fbbdecefae8f4dd324d260eef2b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









