### PR TITLE
fix: remove coveralls upload

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the GitHub Actions workflows and reusable actions for the FluentDo Agent project. The CI/CD pipeline automates building, testing, packaging, and releasing the agent across multiple platforms.
 
+[![Coverage Status](https://coveralls.io/repos/github/FluentDo/agent/badge.svg)](https://coveralls.io/github/FluentDo/agent)
+
 ## Table of Contents
 
 - [GitHub Actions CI/CD Documentation](#github-actions-cicd-documentation)
@@ -123,14 +125,14 @@ The CI/CD pipeline is designed to:
 
 - Multiple sanitizer configurations (address, undefined, memory, thread)
 - Code coverage reporting using gcovr
-- Coverage reports in multiple formats (HTML, XML, JSON, Coveralls)
+- Coverage reports in multiple formats (HTML, XML, JSON)
 - Runs on Namespace profile runners (4 vCPU, 8GB RAM)
 - 15-minute timeout for test execution
 - Parallel test execution with ctest
 
 **Outputs:**
 
-- Coverage reports (HTML, XML, JSON, Coveralls)
+- Coverage reports (HTML, XML, JSON)
 - Test results
 
 ### Lint

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -133,6 +133,7 @@ jobs:
         continue-on-error: true
         if: matrix.config.name == 'coverage'
         working-directory: source/build
+        # Generating in coveralls format triggers errors so we use Cobertura format for now
         run: |
           gcovr --object-directory . --root .. --gcov-ignore-parse-errors --gcov-ignore-errors \
             --sort uncovered-percent \
@@ -161,7 +162,6 @@ jobs:
           path: |
             source/build/coverage*.*
             source/build/cobertura.xml
-            source/build/coveralls.json
 
       # - name: Breakpoint if tests failed
       #   if: failure() && contains(runner.name, 'nsc-')

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ It also has built-in functionality for:
 3. AI processors for routing (Smart log routing)
 4. Enhanced storage layer (Efficient buffering)
 
-
 ## Support & Lifecycle
 
 ### Version Support Matrix
@@ -173,6 +172,8 @@ make
 The Cosign key for our images is [provided](./cosign.pub) in this repo.
 
 Follow the documentation to verify against it: <https://docs.sigstore.dev/cosign/verifying/verify/>.
+
+The GPG key is also [provided](./gpg.pub) that signs packages and checksums.
 
 ### Reporting Security Issues
 


### PR DESCRIPTION
We had to remove coveralls output format to prevent gcov failures but unfortunately left in the attempt to upload it which will always warn so tidying that up.

Also adding badge and readme updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop uploading the Coveralls artifact in the unit-tests workflow to remove errors/warnings from gcovr’s Coveralls format. Docs updated to exclude Coveralls from listed coverage formats, add a Coveralls badge in workflows README, and note the GPG key in README.

Risk: 5

<sup>Written for commit 4921948a630dcb69318b9ec3e27064cfff68deb4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

