### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -378,15 +378,15 @@ jobs:
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
             "docker://${{ env.UBI_IMAGE_NAME }}:${{ env.TAG }}" \
-            "oci-archive:output/fluent-do-agent-container.tar"
+            "oci-archive:output/fluentdo-agent-container.tar"
           skopeo copy \
             --all \
             --remove-signatures \
             --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
             "docker://${{ env.DISTROLESS_IMAGE_NAME }}:${{ env.TAG }}" \
-            "oci-archive:output/fluent-do-agent-container-slim.tar"
-          tar -czvf output/fluent-do-agent-container.tar.gz output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
-          rm -f output/fluent-do-agent-container.tar output/fluent-do-agent-container-slim.tar
+            "oci-archive:output/fluentdo-agent-container-slim.tar"
+          tar -czvf output/fluentdo-agent-container.tar.gz output/fluentdo-agent-container.tar output/fluentdo-agent-container-slim.tar
+          rm -f output/fluentdo-agent-container.tar output/fluentdo-agent-container-slim.tar
         shell: bash
 
       - name: Construct release info
@@ -443,7 +443,7 @@ jobs:
             *.spdx
             output/*.json
             deliverables.tar.gz
-            output/fluent-do-agent-container.tar.gz
+            output/fluentdo-agent-container.tar.gz
             output/package-macos-*
             output/package-windows-*
           fail_on_unmatched_files: false


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/FluentDo/agent/actions/runs/19859059717
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized container artifact names in the build workflow by removing hyphens (fluent-do-agent -> fluentdo-agent) and updated archive/upload paths to match. This fixes release packaging on release/25.10-lts so the upload step finds the tarball.

<sup>Written for commit a3ee18bc3077868b0802a202cfe43cffa486a897. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

