### PR TITLE
fix: exclude legacy RPM targets from GPG signing with recent key

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,9 @@ if [ -n "${DISABLE_CONTROL_CHARS:-}" ]; then
 	NC=''
 fi
 
+# Any additional options to pass to the package manager
+INSTALL_ADDITIONAL_PARAMETERS=${INSTALL_ADDITIONAL_PARAMETERS:-}
+
 # ============================================================================
 # Prerequisites Check
 # ============================================================================
@@ -674,24 +677,27 @@ install_package() {
 				log_warning "Unable to update repositories"
 				log_debug "$SUDO $PKG_MANAGER update failed"
 			fi
-            log_debug "Running: $SUDO $PKG_MANAGER install -y $package_file"
-            if ! $SUDO "$PKG_MANAGER" install -y "$package_file"; then
+            log_debug "Running: $SUDO $PKG_MANAGER install -y $INSTALL_ADDITIONAL_PARAMETERS $package_file"
+            # shellcheck disable=SC2086
+            if ! $SUDO "$PKG_MANAGER" install -y $INSTALL_ADDITIONAL_PARAMETERS "$package_file"; then
                 log_error "Failed to install .deb package"
                 return 1
             fi
             ;;
         rpm)
             log_debug "Installing .rpm package"
-            log_debug "Running: $SUDO $PKG_MANAGER install -y $package_file"
-            if ! $SUDO "$PKG_MANAGER" install -y "$package_file"; then
+            log_debug "Running: $SUDO $PKG_MANAGER install -y $INSTALL_ADDITIONAL_PARAMETERS $package_file"
+            # shellcheck disable=SC2086
+            if ! $SUDO "$PKG_MANAGER" install -y $INSTALL_ADDITIONAL_PARAMETERS "$package_file"; then
                 log_error "Failed to install .rpm package"
                 return 1
             fi
             ;;
         apk)
             log_debug "Installing .apk package"
-            log_debug "Running: $SUDO $PKG_MANAGER add --allow-untrusted $package_file"
-            if ! $SUDO "$PKG_MANAGER" add --allow-untrusted "$package_file"; then
+            log_debug "Running: $SUDO $PKG_MANAGER add --allow-untrusted $INSTALL_ADDITIONAL_PARAMETERS $package_file"
+            # shellcheck disable=SC2086
+            if ! $SUDO "$PKG_MANAGER" add --allow-untrusted $INSTALL_ADDITIONAL_PARAMETERS "$package_file"; then
                 log_error "Failed to install .apk package"
                 return 1
             fi

--- a/scripts/sign-packages.sh
+++ b/scripts/sign-packages.sh
@@ -31,8 +31,18 @@ fi
 if [[ -n "$GPG_KEY" ]]; then
 	if command -v rpm &>/dev/null; then
 		echo "INFO: RPM signing"
-		# Sign all RPMs
+
+		# Now sign everything
 		find "$BASE_DIR" -type f -name "*.rpm" -print -exec rpm --define "_gpg_name $GPG_KEY" --addsign {} \;
+
+		# Legacy targets have some issues with more recent GPG keys: https://superuser.com/a/977804
+		excludePackages=("package-centos-6" "package-centos-7" "package-centos-8" "package-almalinux-8" "package-rockylinux-8")
+		for i in "${excludePackages[@]}"; do
+		  if [[ -d "$BASE_DIR"/"$i" ]]; then
+			echo "Removing GPG key from legacy package: $i"
+			find "$BASE_DIR"/"$i" -type f -name "*.rpm" -print -exec rpm --delsign {} \;
+		  fi
+		done
 	else
 		echo "WARNING: skipping RPM signing"
 	fi


### PR DESCRIPTION
Legacy OS targets cannot handle more recent GPG keys and just trigger failures when attempting to install the package - even with `--nogpgcheck` or similar.

See https://serverfault.com/a/624910

```text
RPM fails to validate signed packages, didn't understand v4 GPG signatures but didn't notice it didn't understand them, didn't understand some key sizes and types but didn't notice it didn't understand that, and also choked on subkeys!

You must force GnuPG to use v3 signatures when signing on/for RHEL / CentOS 5 or 6:

%__gpg_sign_cmd %{__gpg} \
    gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor \
    --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" \
    -sbo %{__signature_filename} %{__plaintext_filename}
because RPM doesn't check the sigversion or validate the signed package after signing it, and these distros contain GPG versions that default to v4 signatures.

You must also generate a 2048 bit signing-only RSA key with no subkeys.

A couple of relevant bugs:

[RPM seems unable to find (GPG) RSA keys for verifying signatures](https://bugzilla.redhat.com/show_bug.cgi?id=86012)

[rpm --sign with 4096bit or 2048bit RSA key creates broken signature](https://bugzilla.redhat.com/show_bug.cgi?id=436812)
```








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop signing RPMs for legacy distros (CentOS 6–8, AlmaLinux 8, Rocky 8) to prevent install failures with newer GPG keys. Installs on these platforms now work, and supported targets remain signed.

- **Bug Fixes**
  - scripts/sign-packages.sh: sign all RPMs, then remove signatures from legacy targets.
  - install.sh: add INSTALL_ADDITIONAL_PARAMETERS to pass extra package manager flags (e.g., --nogpgcheck) during installation.

<sup>Written for commit dd80bdd990e274ea7f092491e114aa73aefe0509. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







