### PR TITLE
test: fix Debian checks

### DIFF
--- a/testing/bats/tests/functional/linux/verify-deb.bats
+++ b/testing/bats/tests/functional/linux/verify-deb.bats
@@ -16,7 +16,7 @@ setup() {
     fi
 
     export PACKAGE_NAME="fluentdo-agent"
-    if ! dpkg -l | grep -q "ii.*$PACKAGE_NAME" ; then
+    if ! dpkg -s "$PACKAGE_NAME" ; then
         skip "Skipping test: $PACKAGE_NAME DEB not installed"
     fi
 }
@@ -30,24 +30,19 @@ teardown() {
 @test "DEB package is installed" {
     run dpkg -l
     assert_success
-    assert_output --partial "ii.*$PACKAGE_NAME"
+    assert_output --partial "$PACKAGE_NAME"
 }
 
 @test "DEB package version is correct" {
-    run dpkg -l "$PACKAGE_NAME" | grep "$PACKAGE_NAME" | awk '{print $3}'
+    run dpkg -s "$PACKAGE_NAME"
     assert_success
-    assert_output --partial "$FLUENTDO_AGENT_VERSION"
+    assert_output --partial "Version: $FLUENTDO_AGENT_VERSION"
+    assert_output --partial 'Status: install ok installed'
 }
 
 @test "DEB package provides fluentdo-agent" {
     run apt-cache policy "$PACKAGE_NAME"
     assert_success
-}
-
-@test "DEB conffiles are properly installed" {
-    run dpkg --status "$PACKAGE_NAME"
-    assert_success
-    assert_output --partial 'Status'
 }
 
 @test "DEB systemd service is in package" {

--- a/testing/bats/tests/functional/linux/verify-files.bats
+++ b/testing/bats/tests/functional/linux/verify-files.bats
@@ -16,11 +16,11 @@ setup() {
 
     # Ensure we skip tests in the container
     if command -v rpm &>/dev/null; then
-        if ! rpm -qa | grep -q "fluentdo-agent" ; then
+        if ! rpm -qa | grep -q "$PACKAGE_NAME" ; then
             skip "Skipping test: $PACKAGE_NAME RPM not installed"
         fi
     elif command -v dpkg &>/dev/null; then
-        if ! dpkg -l | grep -q "ii.*fluentdo-agent" ; then
+        if ! dpkg -s "$PACKAGE_NAME" ; then
             skip "Skipping test: $PACKAGE_NAME DEB not installed"
         fi
     fi


### PR DESCRIPTION
Resolves #144 by correctly checking for Debian packages.

Tested locally to confirm all tests run appropriately for Ubuntu and Almalinux targets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Debian package checks in the test suite so Debian/Ubuntu runs pass reliably. Updates Bats tests to use dpkg -s and correct assertions, addressing #144.

- **Bug Fixes**
  - Use dpkg -s instead of parsing dpkg -l output.
  - Assert "Version: <version>" and "Status: install ok installed".
  - Use "$PACKAGE_NAME" consistently in grep checks for RPM and DEB paths.

<sup>Written for commit f777537c0245837b6d24a6e90fb57fb01de39cb0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

