### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -62,7 +62,7 @@ jobs:
             - name: Create a PR with the update
               if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
               id: cpr
-              uses: peter-evans/create-pull-request@v7
+              uses: peter-evans/create-pull-request@v8
               with:
                   commit-message: "ci: update workflows on ${{ matrix.branch }} from main"
                   signoff: true

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -162,7 +162,7 @@ jobs:
             - name: Create a PR with the update
               if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
               id: cpr
-              uses: peter-evans/create-pull-request@v7
+              uses: peter-evans/create-pull-request@v8
               with:
                   commit-message: "ci: update to new version ${{ steps.get-version.outputs.next_tag }}"
                   signoff: true


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/FluentDo/agent/actions/runs/20099199582
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade peter-evans/create-pull-request action from v7 to v8 in the release/25.10-lts workflows to keep CI current and avoid deprecations.

- **Dependencies**
  - update-lts-branches.yaml: v7 → v8
  - update-version.yaml: v7 → v8

<sup>Written for commit f4585ddb30531c5c4f465c6d225f92208584a2ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

