### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Restore cached packages of vcpkg
         id: cache-vcpkg-sources
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             C:\vcpkg\installed
@@ -128,7 +128,7 @@ jobs:
 
       - name: Save packages of vcpkg
         id: save-vcpkg-sources
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             C:\vcpkg\installed


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/FluentDo/agent/actions/runs/20165500253
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Windows packages build workflow to use actions/cache v5 for restore and save, improving caching reliability for vcpkg on release/25.10-lts.

- **Dependencies**
  - Bump actions/cache/restore and actions/cache/save from v4 to v5 in .github/workflows/call-build-windows-packages.yaml.

<sup>Written for commit 906632005d67170b261843a874d80776f9f39e09. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

