### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -294,7 +294,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all artefacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: output
           pattern: |

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -162,7 +162,7 @@ jobs:
         shell: bash
 
       - name: Upload ${{ matrix.target }} digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}-digests-${{ steps.output-name.outputs.sanitised_image_base }}-${{ matrix.platform }}
           path: digests/*
@@ -244,7 +244,7 @@ jobs:
         shell: bash
 
       - name: Download digests for all architectures of ${{ steps.output-name.outputs.sanitised_image_base }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: production-digests-${{ steps.output-name.outputs.sanitised_image_base }}-*
           path: digests/

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -131,7 +131,7 @@ jobs:
       # We also want this package to be the root directory so remove any extra nesting:
       # e.g. for centos/7 + standard we include everything from 'source/packaging/packages/centos/7/'
       - name: Upload the ${{ matrix.distro }} artefacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.get_package_name.outputs.package-name }}
           path: |

--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -97,7 +97,7 @@ jobs:
               working-directory: source/build
 
             - name: Upload build packages
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v6
               with:
                   name: package-macos-${{ matrix.config.package }}
                   path: |

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -181,7 +181,7 @@ jobs:
         working-directory: source/build
 
       - name: Upload build packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: package-windows-${{ matrix.config.arch }}
           path: |

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download package
         if: ${{ !env.ACT }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ${{ steps.get_package_name.outputs.package-name }}
           path: downloads/
@@ -208,7 +208,7 @@ jobs:
           support-install: false
 
       - name: Download package
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ${{ matrix.package }}
           path: downloads/

--- a/.github/workflows/lint-packages.yaml
+++ b/.github/workflows/lint-packages.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download package
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: package-ubuntu-24.04
           path: downloads/

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.config.name == 'coverage'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-reports
           path: |


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/FluentDo/agent/actions/runs/20372299967
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh CI workflows on release/25.10-lts to use the latest artifact actions. Upgrades actions/upload-artifact to v6 and actions/download-artifact to v7 across build, package, test, lint, and unit-test jobs.

- **Dependencies**
  - actions/upload-artifact: v5 → v6
  - actions/download-artifact: v6 → v7

<sup>Written for commit 6bd1ec54502496edbeb2d3b4d2fdd858f50eda4a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

