### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -302,7 +302,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Sign image with a key if defined
         if: ${{ env.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/call-test-containers-k8s.yaml
+++ b/.github/workflows/call-test-containers-k8s.yaml
@@ -56,7 +56,7 @@ jobs:
           version: v3.19.2
 
       - name: Set up Kubectl
-        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b # v5.0.0
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/23803234327
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows on `release/25.10-lts` to use newer pinned actions for image signing and kubectl setup. No pipeline logic changes.

- **Dependencies**
  - `sigstore/cosign-installer`: v4.1.0 → v4.1.1 in `call-build-containers.yaml` (updated SHA).
  - `azure/setup-kubectl`: v4.0.1 → v5.0.0 in `call-test-containers-k8s.yaml` (updated SHA).

<sup>Written for commit 4984f1c2cc4eeeae0080595dc6dad4367b90245c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

