### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -356,7 +356,7 @@ jobs:
         shell: bash
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -442,7 +442,7 @@ jobs:
       - name: Create release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         # This may fail for workflow_dispatch if the release already exists
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           append_body: true
           body: |

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -100,13 +100,13 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to docker.io for authorised pulls
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build and push by digest the standard ${{ matrix.target }} image
         id: production
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           # Use path context rather than Git context as we want local files
           context: .
@@ -164,7 +164,7 @@ jobs:
         shell: bash
 
       - name: Upload ${{ matrix.target }} digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}-digests-${{ steps.output-name.outputs.sanitised_image_base }}-${{ matrix.platform }}
           path: digests/*
@@ -193,7 +193,7 @@ jobs:
       - name: Build and push the test image
         if: matrix.platform == 'amd64'
         id: test
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ${{ inputs.definition }}
@@ -262,7 +262,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -295,7 +295,7 @@ jobs:
       IMAGE: ${{ needs.build-container-image-manifest.outputs.tag }}
     steps:
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -99,13 +99,13 @@ jobs:
 
       - name: Log in to docker.io for authorised pulls
         if: inputs.dockerhub-username != ''
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
 
       - name: Log in to the GHCR registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -133,7 +133,7 @@ jobs:
       # We also want this package to be the root directory so remove any extra nesting:
       # e.g. for centos/7 + standard we include everything from 'source/packaging/packages/centos/7/'
       - name: Upload the ${{ matrix.distro }} artefacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.get_package_name.outputs.package-name }}
           path: |

--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -99,7 +99,7 @@ jobs:
               working-directory: source/build
 
             - name: Upload build packages
-              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: package-macos-${{ matrix.config.package }}
                   path: |

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Restore cached packages of vcpkg
         id: cache-vcpkg-sources
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             C:\vcpkg\installed
@@ -130,7 +130,7 @@ jobs:
 
       - name: Save packages of vcpkg
         id: save-vcpkg-sources
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             C:\vcpkg\installed
@@ -185,7 +185,7 @@ jobs:
         working-directory: source/build
 
       - name: Upload build packages
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: package-windows-${{ matrix.config.arch }}
           path: |

--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -24,7 +24,7 @@ jobs:
             TAG: ${{ inputs.version }}
         steps:
             - name: Log in to the Container registry
-              uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
           - promote-ghcr-images
         steps:
             - name: Log in to the Container registry
-              uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}

--- a/.github/workflows/call-test-containers-k8s.yaml
+++ b/.github/workflows/call-test-containers-k8s.yaml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.github-token }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
           version: v3.19.2
 
       - name: Set up Kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b # v5.0.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -63,7 +63,7 @@ jobs:
           token: ${{ secrets.github-token }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -120,7 +120,7 @@ jobs:
           token: ${{ secrets.github-token }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -146,7 +146,7 @@ jobs:
       packages: read
     steps:
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Log in to Dockerhub
         if: ${{ !env.ACT }}
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Log in to Dockerhub
         if: ${{ !env.ACT }}
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -48,7 +48,7 @@ jobs:
 
             - name: Parse /build comment
               id: parse
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const body = (context.payload.comment?.body || '').trim();
@@ -174,7 +174,7 @@ jobs:
         steps:
             - name: Post results as PR comment
               if: needs.pr-build-comment.outputs.should-run == 'true'
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   PR_NUMBER: ${{ needs.pr-build-comment.outputs.pr-number }}
                   WINDOWS_REQUESTED: ${{ needs.pr-build-comment.outputs.build-windows }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.config.name == 'coverage'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-reports
           path: |

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -62,7 +62,7 @@ jobs:
             - name: Create a PR with the update
               if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
               id: cpr
-              uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
               with:
                   commit-message: "ci: update workflows on ${{ matrix.branch }} from main"
                   signoff: true

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -165,7 +165,7 @@ jobs:
             - name: Create a PR with the update
               if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
               id: cpr
-              uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
               with:
                   commit-message: "ci: update to new version ${{ steps.get-version.outputs.next_tag }}"
                   signoff: true


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/24895826908
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows on `release/25.10-lts` to match `main`, bumping pinned GitHub Actions for security and reliability. No changes to build outputs or release artifacts.

- **Dependencies**
  - Docker actions: `docker/login-action` → v4.1.0, `docker/build-push-action` → v7.1.0
  - Artifacts and cache: `actions/upload-artifact` → v7.0.1, `actions/cache` restore/save → v5.0.5
  - Release tooling: `softprops/action-gh-release` → v3.0.0, `peter-evans/create-pull-request` → latest pinned commit
  - Test/tools: `azure/setup-kubectl` → v5.1.0, `actions/github-script` → v9.0.0

<sup>Written for commit 38d05a0b2d9773a66221a47ef867432df939e517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

