### PR TITLE
fix: resolve release creation failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -289,7 +289,9 @@ jobs:
     permissions:
       packages: read
       actions: read
-      contents: write
+      contents: read
+      # We no longer need write permissions as we use a PAT due to https://github.com/softprops/action-gh-release/issues/411#issuecomment-4062182124
+      # contents: write
       id-token: write
     env:
       UBI_IMAGE_NAME: ghcr.io/telemetryforge/agent/ubi
@@ -439,12 +441,23 @@ jobs:
           fi
         shell: bash
 
+      - id: get-secrets-release
+        if: github.ref_type == 'tag'
+        name: Get secrets from GCP Secret Manager for release creation
+        # We need a custom PAT for creating a release on an older commit SHA
+        # https://github.com/softprops/action-gh-release/issues/411#issuecomment-4062182124
+        uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
+        with:
+          secrets: |-
+            github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
+
       - name: Create release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: github.ref_type == 'tag'
         # This may fail for workflow_dispatch if the release already exists
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           append_body: true
+          token: ${{ steps.get-secrets-release.outputs.github-pat }}
           body: |
             Telemetry Forge Agent release for ${{ github.ref_name }} version
 


### PR DESCRIPTION
Resolves #256 when creating a release for the non-latest commit SHA due to an issue with token permissions so switches to a PAT.

See https://github.com/softprops/action-gh-release/pull/758 for doc updates on the action side.

> When creating a new tag for an older commit, `github.token` may not have permission to create the ref; use a PAT or another token with sufficient contents permissions if you hit `403 Resource not accessible by integration`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release creation when tagging older commits by using a PAT instead of `github.token`, and tightening workflow permissions. Resolves #256.

- **Bug Fixes**
  - Fetch PAT from GCP using `google-github-actions/get-secretmanager-secrets@v3` and pass it to `softprops/action-gh-release`.
  - Gate release step on `github.ref_type == 'tag'` for clarity.
  - Change workflow `contents` permission from write to read; PAT handles ref and release creation.

<sup>Written for commit ccb59e60d64cd5e9a05f97daf3671ebcc2538696. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

