### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -289,7 +289,9 @@ jobs:
     permissions:
       packages: read
       actions: read
-      contents: write
+      contents: read
+      # We no longer need write permissions as we use a PAT due to https://github.com/softprops/action-gh-release/issues/411#issuecomment-4062182124
+      # contents: write
       id-token: write
     env:
       UBI_IMAGE_NAME: ghcr.io/telemetryforge/agent/ubi
@@ -439,12 +441,23 @@ jobs:
           fi
         shell: bash
 
+      - id: get-secrets-release
+        if: github.ref_type == 'tag'
+        name: Get secrets from GCP Secret Manager for release creation
+        # We need a custom PAT for creating a release on an older commit SHA
+        # https://github.com/softprops/action-gh-release/issues/411#issuecomment-4062182124
+        uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
+        with:
+          secrets: |-
+            github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
+
       - name: Create release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: github.ref_type == 'tag'
         # This may fail for workflow_dispatch if the release already exists
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           append_body: true
+          token: ${{ steps.get-secrets-release.outputs.github-pat }}
           body: |
             Telemetry Forge Agent release for ${{ github.ref_name }} version
 


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/25160509177
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release creation on `release/25.10-lts` to use a GCP-stored PAT and narrow permissions to least-privilege. This fixes failures when creating releases for older commit SHAs and ensures tag-based releases run reliably.

- **CI**
  - Fetch PAT from GCP with `google-github-actions/get-secretmanager-secrets@v3` when `github.ref_type == 'tag'`.
  - Pass the PAT to `softprops/action-gh-release`; change condition to `github.ref_type == 'tag'`.
  - Reduce permissions: `contents: read` (remove write) while keeping `id-token: write`.
  - Workaround for `softprops/action-gh-release` creating releases on older SHAs.

<sup>Written for commit dead35ce47c8a19f6fb0bf91ac08171c98cd20f4. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/262?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

