### PR TITLE
feat: use StepSecurity to harden CI egress

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,14 @@ on:
       - release/**
     tags:
       - v*
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
+# Default to least permissions and then we can add as needed for each job.
+# This is a secure by default approach and also makes it easier to reason 
+# about permissions for each job since they are not implicit from the workflow
+permissions: {}
 
 # Cancel any running jobs for PRs on a new commit
 concurrency:
@@ -33,6 +41,11 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
       oss-version: ${{ steps.set-oss-version.outputs.oss-version }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -261,6 +274,11 @@ jobs:
       # Add additional jobs here as required that must complete
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
@@ -298,6 +316,11 @@ jobs:
       DISTROLESS_IMAGE_NAME: ghcr.io/telemetryforge/agent/debian
       TAG: ${{ needs.build-image.outputs.version }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # We need full history to be able to detect branch ancestry
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -276,7 +276,7 @@ jobs:
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with: 
+        with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ env:
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 # Default to least permissions and then we can add as needed for each job.
-# This is a secure by default approach and also makes it easier to reason 
+# This is a secure by default approach and also makes it easier to reason
 # about permissions for each job since they are not implicit from the workflow
 permissions: {}
 
@@ -276,8 +276,8 @@ jobs:
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+        with: 
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
@@ -319,7 +319,7 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # We need full history to be able to detect branch ancestry

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -55,6 +55,10 @@ on:
         description: Just the container version (tag)
         value: ${{ jobs.build-container-image-manifest.outputs.version }}
 
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   # Taken from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   # We split this out to make it easier to restart just one of them if it fails and do all in parallel
@@ -73,6 +77,11 @@ jobs:
     name: ${{ matrix.platform }}/${{ matrix.target }} container image build
     runs-on: ${{ (contains(matrix.platform, 'arm') && inputs.arm-runner-label) || inputs.amd-runner-label }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -223,6 +232,11 @@ jobs:
       image: ${{ inputs.image-base }}
       version: ${{ steps.meta.outputs.version }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Extract metadata from Github
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -294,6 +308,11 @@ jobs:
     env:
       IMAGE: ${{ needs.build-container-image-manifest.outputs.tag }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -235,7 +235,7 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - name: Extract metadata from Github
         id: meta
@@ -311,7 +311,7 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -51,6 +51,11 @@ on:
       dockerhub-token:
         description: The Dockerhub token to use for authenticated pulls (not pushes).
         required: false
+
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   build-packages:
     name: agent - ${{ matrix.distro }} package build and upload
@@ -64,6 +69,11 @@ jobs:
       matrix:
         distro: ${{ fromJson(inputs.target-matrix) }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout ${{ inputs.ref }} code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -1,116 +1,116 @@
 ---
 name: Build macOS packages
 on:
-    workflow_call:
-        inputs:
-            version:
-                description: The version we are building for (as a numeric value 1.2.3).
-                required: true
-                type: string
-            ref:
-                description: The commit, tag or branch of Fluent Bit to checkout for building that creates the version above.
-                type: string
-                required: true
-            nightly-build-info:
-                description: Any special information to add to the nightly build information string.
-                required: false
-                type: string
-                default: ""
+  workflow_call:
+    inputs:
+      version:
+        description: The version we are building for (as a numeric value 1.2.3).
+        required: true
+        type: string
+      ref:
+        description: The commit, tag or branch of Fluent Bit to checkout for building that creates the version above.
+        type: string
+        required: true
+      nightly-build-info:
+        description: Any special information to add to the nightly build information string.
+        required: false
+        type: string
+        default: ""
 env:
   # Set once from repo variable or override here for testing
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 jobs:
-    call-build-macos-package:
-        name: Building ${{ matrix.config.name }} package
-        runs-on: ${{ matrix.config.runner }}
-        timeout-minutes: 60
-        strategy:
-            fail-fast: false
-            matrix:
-                config:
-                    - name: "macOS Intel silicon"
-                      runner: macos-15-intel
-                      package: "intel"
-                    - name: "macOS Apple silicon"
-                      runner: macos-15
-                      package: "apple"
-        permissions:
-            contents: read
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+  call-build-macos-package:
+    name: Building ${{ matrix.config.name }} package
+    runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "macOS Intel silicon"
+            runner: macos-15-intel
+            package: "intel"
+          - name: "macOS Apple silicon"
+            runner: macos-15
+            package: "apple"
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
-            - name: Checkout ${{ inputs.ref }} code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  ref: ${{ inputs.ref }}
-                  repository: telemetryforge/agent
+      - name: Checkout ${{ inputs.ref }} code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          repository: telemetryforge/agent
 
-            - name: Install dependencies
-              run: |
-                  brew update
-                  # We ignore errors here as some packages may already be installed
-                  brew install bison flex gnu-sed libyaml openssl pkgconfig libgit2 cyrus-sasl rocksdb libtool || true
-                  # Remove dynamic linkage for libyaml
-                  rm -fv $(brew --prefix libyaml)/lib/*.dylib
-                  # Remove dynamic linkage for zstd added by curl install
-                  rm -fv $(brew --prefix zstd)/lib/*.dylib
-                  # Remove dynamic linkage for openssl
-                  rm -fv $(brew --prefix openssl)/lib/*.dylib
-                  # Keep libgit2 dylib (Homebrew doesn't provide static libs)
-                  # rm -fv $(brew --prefix libgit2)/lib/*.dylib
-                  # Remove dynamic linkage for cyrus-sasl
-                  rm -fv $(brew --prefix cyrus-sasl)/lib/*.dylib
+      - name: Install dependencies
+        run: |
+          brew update
+          # We ignore errors here as some packages may already be installed
+          brew install bison flex gnu-sed libyaml openssl pkgconfig libgit2 cyrus-sasl rocksdb libtool || true
+          # Remove dynamic linkage for libyaml
+          rm -fv $(brew --prefix libyaml)/lib/*.dylib
+          # Remove dynamic linkage for zstd added by curl install
+          rm -fv $(brew --prefix zstd)/lib/*.dylib
+          # Remove dynamic linkage for openssl
+          rm -fv $(brew --prefix openssl)/lib/*.dylib
+          # Keep libgit2 dylib (Homebrew doesn't provide static libs)
+          # rm -fv $(brew --prefix libgit2)/lib/*.dylib
+          # Remove dynamic linkage for cyrus-sasl
+          rm -fv $(brew --prefix cyrus-sasl)/lib/*.dylib
 
-            - name: Install cmake
-              uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
-              with:
-                  cmake-version: "3.31.6"
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
+        with:
+          cmake-version: "3.31.6"
 
-            - name: Ensure we apply specific version from tag
-              run: ./scripts/setup-code.sh
-              shell: bash
-              env:
-                  TELEMETRY_FORGE_AGENT_VERSION: ${{ inputs.version }}
-                  # Support legacy version variable for backwards compatibility
-                  FLUENTDO_AGENT_VERSION: ${{ inputs.version }}
+      - name: Ensure we apply specific version from tag
+        run: ./scripts/setup-code.sh
+        shell: bash
+        env:
+          TELEMETRY_FORGE_AGENT_VERSION: ${{ inputs.version }}
+          # Support legacy version variable for backwards compatibility
+          FLUENTDO_AGENT_VERSION: ${{ inputs.version }}
 
-            - name: Ensure we have a build directory
-              run: mkdir -p source/build
-              shell: bash
+      - name: Ensure we have a build directory
+        run: mkdir -p source/build
+        shell: bash
 
-            - name: Deltas
-              run: git diff
-              shell: bash
+      - name: Deltas
+        run: git diff
+        shell: bash
 
-            - name: Build hardened Fluent Bit packages
-              run: |
-                  export LIBRARY_PATH="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib:$LIBRARY_PATH"
-                  export PKG_CONFIG_PATH="$(brew --prefix cyrus-sasl)/lib/pkgconfig:$PKG_CONFIG_PATH"
+      - name: Build hardened Fluent Bit packages
+        run: |
+          export LIBRARY_PATH="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib:$LIBRARY_PATH"
+          export PKG_CONFIG_PATH="$(brew --prefix cyrus-sasl)/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-                  cmake \
-                    -DOPENSSL_USE_STATIC_LIBS=ON \
-                    -DCMAKE_BUILD_TYPE=Release \
-                    -DCPACK_GENERATOR=productbuild \
-                    -DFLB_NIGHTLY_BUILD=${{ inputs.nightly-build-info }} ../
+          cmake \
+            -DOPENSSL_USE_STATIC_LIBS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCPACK_GENERATOR=productbuild \
+            -DFLB_NIGHTLY_BUILD=${{ inputs.nightly-build-info }} ../
 
-                  cmake --build .
-                  cpack -G productbuild
-              working-directory: source/build
+          cmake --build .
+          cpack -G productbuild
+        working-directory: source/build
 
-            - name: Check linkage of the built agents
-              continue-on-error: true
-              run: |
-                  DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 DYLD_PRINT_RPATHS=1 bin/*-agent --dry-run
-              working-directory: source/build
+      - name: Check linkage of the built agents
+        continue-on-error: true
+        run: |
+          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 DYLD_PRINT_RPATHS=1 bin/*-agent --dry-run
+        working-directory: source/build
 
-            - name: Upload build packages
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              with:
-                  name: package-macos-${{ matrix.config.package }}
-                  path: |
-                      source/build/*-agent-*.pkg
-                  if-no-files-found: error
+      - name: Upload build packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-macos-${{ matrix.config.package }}
+          path: |
+            source/build/*-agent-*.pkg
+          if-no-files-found: error

--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -16,6 +16,10 @@ on:
                 required: false
                 type: string
                 default: ""
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
     call-build-macos-package:
         name: Building ${{ matrix.config.name }} package
@@ -34,6 +38,11 @@ jobs:
         permissions:
             contents: read
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - name: Checkout ${{ inputs.ref }} code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ""
+
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   call-build-windows-package:
     runs-on: windows-2025
@@ -38,6 +43,11 @@ jobs:
       VCPKG_BUILD_TYPE: release
       VCPKG_LIBRARY_LINKAGE: static
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout ${{ inputs.ref }} code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -12,6 +12,9 @@ on:
 env:
     UBI_IMAGE_NAME: ghcr.io/telemetryforge/agent/ubi
     DISTROLESS_IMAGE_NAME: ghcr.io/telemetryforge/agent/debian
+    # Set once from repo variable or override here for testing
+    STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
     promote-ghcr-images:
         name: Promote container images to top-level ghcr.io registries
@@ -23,6 +26,11 @@ jobs:
             OUTPUT_IMAGE_NAME: ghcr.io/telemetryforge/agent
             TAG: ${{ inputs.version }}
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - name: Log in to the Container registry
               uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
@@ -77,6 +85,11 @@ jobs:
           # We must use the top-level image here - see above
           - promote-ghcr-images
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - name: Log in to the Container registry
               uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:

--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -1,127 +1,127 @@
 name: Reusable workflow to publish release images to appropriate locations
 on:
-    workflow_call:
-        inputs:
-            version:
-                description: The container tag to promote to the various registries.
-                type: string
-                required: true
-        secrets:
-            github-token:
-                required: true
+  workflow_call:
+    inputs:
+      version:
+        description: The container tag to promote to the various registries.
+        type: string
+        required: true
+    secrets:
+      github-token:
+        required: true
 env:
-    UBI_IMAGE_NAME: ghcr.io/telemetryforge/agent/ubi
-    DISTROLESS_IMAGE_NAME: ghcr.io/telemetryforge/agent/debian
-    # Set once from repo variable or override here for testing
-    STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+  UBI_IMAGE_NAME: ghcr.io/telemetryforge/agent/ubi
+  DISTROLESS_IMAGE_NAME: ghcr.io/telemetryforge/agent/debian
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 jobs:
-    promote-ghcr-images:
-        name: Promote container images to top-level ghcr.io registries
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
+  promote-ghcr-images:
+    name: Promote container images to top-level ghcr.io registries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      OUTPUT_IMAGE_NAME: ghcr.io/telemetryforge/agent
+      TAG: ${{ inputs.version }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.github-token }}
+
+      - name: Promote UBI images
+        run: |
+          docker pull "$UBI_IMAGE_NAME:$TAG"
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$DEST_CREDS" \
+              "docker://$UBI_IMAGE_NAME:$TAG" \
+              "docker://$OUTPUT_IMAGE_NAME:$TAG"
         env:
-            OUTPUT_IMAGE_NAME: ghcr.io/telemetryforge/agent
-            TAG: ${{ inputs.version }}
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          DEST_CREDS: ${{ github.actor }}:${{ secrets.github-token }}
+        shell: bash
 
-            - name: Log in to the Container registry
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.github-token }}
-
-            - name: Promote UBI images
-              run: |
-                  docker pull "$UBI_IMAGE_NAME:$TAG"
-                  docker run --rm  \
-                    quay.io/skopeo/stable:latest \
-                    copy \
-                      --all \
-                      --retry-times 10 \
-                      --src-no-creds \
-                      --dest-creds "$DEST_CREDS" \
-                      "docker://$UBI_IMAGE_NAME:$TAG" \
-                      "docker://$OUTPUT_IMAGE_NAME:$TAG"
-              env:
-                  DEST_CREDS: ${{ github.actor }}:${{ secrets.github-token }}
-              shell: bash
-
-            - name: Promote distroless images
-              run: |
-                  docker pull "$DISTROLESS_IMAGE_NAME:$TAG"
-                  docker run --rm  \
-                    quay.io/skopeo/stable:latest \
-                    copy \
-                      --all \
-                      --retry-times 10 \
-                      --src-no-creds \
-                      --dest-creds "$DEST_CREDS" \
-                      "docker://$DISTROLESS_IMAGE_NAME:$TAG" \
-                      "docker://$OUTPUT_IMAGE_NAME:${TAG:?}-slim"
-              env:
-                  DEST_CREDS: ${{ github.actor }}:${{ secrets.github-token }}
-              shell: bash
-
-    promote-redhat-catalog-images:
-        name: Promote UBI image to Red Hat catalog
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: read
-            # Required for GCP secrets access
-            id-token: write
+      - name: Promote distroless images
+        run: |
+          docker pull "$DISTROLESS_IMAGE_NAME:$TAG"
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$DEST_CREDS" \
+              "docker://$DISTROLESS_IMAGE_NAME:$TAG" \
+              "docker://$OUTPUT_IMAGE_NAME:${TAG:?}-slim"
         env:
-          # We must match up the official image we have used for publishing upstream
-          RHEL_SOURCE_IMAGE: ghcr.io/telemetryforge/agent
-        needs:
-          # We must use the top-level image here - see above
-          - promote-ghcr-images
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          DEST_CREDS: ${{ github.actor }}:${{ secrets.github-token }}
+        shell: bash
 
-            - name: Log in to the Container registry
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.github-token }}
+  promote-redhat-catalog-images:
+    name: Promote UBI image to Red Hat catalog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      # Required for GCP secrets access
+      id-token: write
+    env:
+      # We must match up the official image we have used for publishing upstream
+      RHEL_SOURCE_IMAGE: ghcr.io/telemetryforge/agent
+    needs:
+      # We must use the top-level image here - see above
+      - promote-ghcr-images
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
-            - name: Set up preflight binary
-              uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
-              with:
-                preflight: latest
-                source: github
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.github-token }}
 
-            - name: Authenticate with GCP
-              uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-              with:
-                workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
-                service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
+      - name: Set up preflight binary
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
+        with:
+          preflight: latest
+          source: github
 
-            - name: Get Red Hat API key
-              id: get-secrets
-              # This step retrieves secrets from GCP Secret Manager and sets them as outputs
-              # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
-              uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
-              with:
-                secrets: |-
-                    redhat-api-key:projects/626836145334/secrets/RHEL_AGENT_PUBLISH_API_KEY
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+          service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
 
-            - name: Submit container to Red Hat for certification
-              run: |
-                preflight check container \
-                    --certification-component-id 68e14199529ca9e0c382582c \
-                    --pyxis-api-token '${{ steps.get-secrets.outputs.redhat-api-key }}' \
-                    --submit $RHEL_SOURCE_IMAGE:${{ inputs.version }}
-              shell: bash
+      - name: Get Red Hat API key
+        id: get-secrets
+        # This step retrieves secrets from GCP Secret Manager and sets them as outputs
+        # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
+        uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
+        with:
+          secrets: |-
+            redhat-api-key:projects/626836145334/secrets/RHEL_AGENT_PUBLISH_API_KEY
+
+      - name: Submit container to Red Hat for certification
+        run: |
+          preflight check container \
+              --certification-component-id 68e14199529ca9e0c382582c \
+              --pyxis-api-token '${{ steps.get-secrets.outputs.redhat-api-key }}' \
+              --submit $RHEL_SOURCE_IMAGE:${{ inputs.version }}
+        shell: bash

--- a/.github/workflows/call-test-containers-k8s.yaml
+++ b/.github/workflows/call-test-containers-k8s.yaml
@@ -24,6 +24,10 @@ on:
       github-token:
         description: Token to use to pull images from GitHub Container Registry.
         required: true
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   test-containers:
     name: Test K8S version ${{ inputs.kind-version }} with ${{ inputs.image }}:${{ inputs.image-tag }}
@@ -36,6 +40,11 @@ jobs:
       FLUENTDO_AGENT_IMAGE: ${{ inputs.image }}
       FLUENTDO_AGENT_TAG: ${{ inputs.image-tag }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -20,6 +20,10 @@ on:
       github-token:
         description: Token to use to pull images from GitHub Container Registry.
         required: true
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   get-meta:
     name: Get meta information required
@@ -29,6 +33,11 @@ jobs:
     outputs:
       kind-versions: ${{ steps.set-meta.outputs.kind-versions }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,6 +64,11 @@ jobs:
     permissions:
       packages: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -112,6 +126,11 @@ jobs:
     permissions:
       packages: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -145,6 +164,11 @@ jobs:
     permissions:
       packages: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -217,6 +241,11 @@ jobs:
       - test-verify-signatures
       - test-bats-container
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -36,6 +36,9 @@ env:
   TELEMETRY_FORGE_AGENT_VERSION: ${{ inputs.version }}
   # Support legacy version variable for backwards compatibility
   FLUENTDO_AGENT_VERSION: ${{ inputs.version }}
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   # This job converts the JSON build-matrix coming in to a matrix of test jobs.
   # We convert using the following rules:
@@ -48,6 +51,11 @@ jobs:
     outputs:
       linux-test-targets: ${{ steps.get_matrix.outputs.linux_test_targets }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Log in to Dockerhub
         if: ${{ !env.ACT }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -113,6 +121,11 @@ jobs:
       matrix:
         config: ${{ fromJson(needs.call-test-packages-get-meta.outputs.linux-test-targets) }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -186,6 +199,11 @@ jobs:
     env:
       FLUENT_BIT_BINARY: ${{ matrix.binary }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -22,6 +22,10 @@ on:
         required: false
         default: true
         type: boolean
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   find-last-good:
     runs-on: ubuntu-latest
@@ -33,6 +37,11 @@ jobs:
       branch: ${{ steps.detect-branch.outputs.branch || 'main' }}
       prefix: ${{ steps.detect-prefix.outputs.prefix || 'v*' }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 25.10 run
@@ -97,6 +106,11 @@ jobs:
     outputs:
       tag_name: ${{ steps.tag_name.outputs.tag_name }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Authenticate with GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/lint-packages.yaml
+++ b/.github/workflows/lint-packages.yaml
@@ -4,11 +4,11 @@ on:
     paths:
       - .github/workflows/lint-packages.yaml
       # Run for any CMake or packaging changes
-      - 'source/cmake/**'
-      - 'source/cpack/**'
-      - 'source/init/**'
-      - 'source/**/CMakeLists.txt'
-      - 'source/packaging/distros/ubuntu/**'
+      - "source/cmake/**"
+      - "source/cpack/**"
+      - "source/init/**"
+      - "source/**/CMakeLists.txt"
+      - "source/packaging/distros/ubuntu/**"
   workflow_dispatch:
 
 env:
@@ -20,7 +20,7 @@ jobs:
     name: Building test package for Ubuntu
     uses: ./.github/workflows/call-build-linux-packages.yaml
     with:
-      version: '99.9.9'
+      version: "99.9.9"
       ref: ${{ github.ref }}
       target-matrix: '["ubuntu/24.04"]'
       amd-runner-label: ubuntu-latest

--- a/.github/workflows/lint-packages.yaml
+++ b/.github/workflows/lint-packages.yaml
@@ -11,6 +11,10 @@ on:
       - 'source/packaging/distros/ubuntu/**'
   workflow_dispatch:
 
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   build-packages-for-ubuntu:
     name: Building test package for Ubuntu
@@ -27,6 +31,11 @@ jobs:
       - build-packages-for-ubuntu
     name: PR - Lintian (Package changes)
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout for config file
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,11 +8,19 @@ on:
       - reopened
   workflow_dispatch:
 
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   hadolint-pr:
     runs-on: ubuntu-latest
     name: PR - Hadolint
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # Ignores do not work: https://github.com/reviewdog/action-hadolint/issues/35 is resolved
       - uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407 # v1.50.5
@@ -21,6 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
@@ -38,6 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
@@ -51,6 +67,10 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +114,10 @@ jobs:
       # For ReviewDog to post comments to the PR
       pull-requests: write
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6  # v2.0.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,17 @@ on:
 env:
   # Set once from repo variable or override here for testing
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+permissions:
+  contents: read
 
 jobs:
   hadolint-pr:
     runs-on: ubuntu-latest
     name: PR - Hadolint
+    permissions:
+      contents: read
+      # For ReviewDog to post comments to the PR
+      pull-requests: write
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -28,6 +34,10 @@ jobs:
   shellcheck-pr:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
+    permissions:
+      contents: read
+      # For ReviewDog to post comments to the PR
+      pull-requests: write
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -59,6 +69,18 @@ jobs:
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=
+        shell: bash
+
+  workflow-file-format-pr:
+    runs-on: ubuntu-latest
+    name: PR - Workflow file format
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: ./scripts/format-actionlint-results.sh
         shell: bash
 
   prchecker-lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6  # v2.0.0
+      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
           skip_push: "true"
           review: "true"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -80,7 +80,7 @@ jobs:
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: ./scripts/format-actionlint-results.sh
+      - run: ./scripts/format-yaml-files.sh
         shell: bash
 
   prchecker-lint:

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -16,6 +16,11 @@ name: Trigger build on PR comment
 # If no platform is specified then nothing is done
 on:
     issue_comment:
+
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
     pr-build-comment:
         name: Build on PR comment
@@ -34,6 +39,10 @@ jobs:
             # Linux targets matrix to build
             linux-targets-json: ${{ steps.parse.outputs.linux_targets_json }}
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
             - name: Log useful info
               run: |
                   echo "PR Number is ${{ github.event.issue.number }}"
@@ -105,6 +114,11 @@ jobs:
         outputs:
             version: ${{ steps.set-version.outputs.version }}
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -172,6 +186,11 @@ jobs:
             - pr-build-linux
         runs-on: ubuntu-latest
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - name: Post results as PR comment
               if: needs.pr-build-comment.outputs.should-run == 'true'
               uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -15,265 +15,265 @@ name: Trigger build on PR comment
 #
 # If no platform is specified then nothing is done
 on:
-    issue_comment:
+  issue_comment:
 
 env:
   # Set once from repo variable or override here for testing
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 jobs:
-    pr-build-comment:
-        name: Build on PR comment
-        # Ignore comments that are not on PRs (i.e. issues)
-        # Trigger only if /build is present in the comment body
-        if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build')}}
-        runs-on: ubuntu-latest
-        outputs:
-            pr-number: ${{ github.event.issue.number }}
-            # Builds should be run (they may fail)
-            should-run: ${{ steps.parse.outputs.should_run }}
-            # Type of build to run
-            build-windows: ${{ steps.parse.outputs.windows }}
-            build-macos: ${{ steps.parse.outputs.macos }}
-            build-linux: ${{ steps.parse.outputs.linux }}
-            # Linux targets matrix to build
-            linux-targets-json: ${{ steps.parse.outputs.linux_targets_json }}
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-            - name: Log useful info
-              run: |
-                  echo "PR Number is ${{ github.event.issue.number }}"
-                  echo "Comment ID is ${{ github.event.comment.id }}"
-                  echo "Comment body is $BODY"
-              shell: bash
-              env:
-                  BODY: ${{ github.event.comment.body }}
+  pr-build-comment:
+    name: Build on PR comment
+    # Ignore comments that are not on PRs (i.e. issues)
+    # Trigger only if /build is present in the comment body
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build')}}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ github.event.issue.number }}
+      # Builds should be run (they may fail)
+      should-run: ${{ steps.parse.outputs.should_run }}
+      # Type of build to run
+      build-windows: ${{ steps.parse.outputs.windows }}
+      build-macos: ${{ steps.parse.outputs.macos }}
+      build-linux: ${{ steps.parse.outputs.linux }}
+      # Linux targets matrix to build
+      linux-targets-json: ${{ steps.parse.outputs.linux_targets_json }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+      - name: Log useful info
+        run: |
+          echo "PR Number is ${{ github.event.issue.number }}"
+          echo "Comment ID is ${{ github.event.comment.id }}"
+          echo "Comment body is $BODY"
+        shell: bash
+        env:
+          BODY: ${{ github.event.comment.body }}
 
-            - name: Debug
-              uses: raven-actions/debug@9dbdeb7eea607a7d73411895c65987e71d59a466 # v1.2.0
+      - name: Debug
+        uses: raven-actions/debug@9dbdeb7eea607a7d73411895c65987e71d59a466 # v1.2.0
 
-            - name: Parse /build comment
-              id: parse
-              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-              with:
-                  script: |
-                      const body = (context.payload.comment?.body || '').trim();
-                      const firstLine = body.split('\n')[0].trim();
-                      const out = {
-                        windows: false,
-                        macos: false,
-                        linuxTargets: [],
-                      };
+      - name: Parse /build comment
+        id: parse
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const body = (context.payload.comment?.body || '').trim();
+            const firstLine = body.split('\n')[0].trim();
+            const out = {
+              windows: false,
+              macos: false,
+              linuxTargets: [],
+            };
 
-                      // Must start with '/build'
-                      if (!/^\/build\b/i.test(firstLine)) {
-                        core.setOutput('should_run', 'false');
-                        core.setOutput('windows', 'false');
-                        core.setOutput('macos', 'false');
-                        core.setOutput('linux', 'false');
-                        core.setOutput('linux_targets_json', '[]');
-                        return;
-                      }
+            // Must start with '/build'
+            if (!/^\/build\b/i.test(firstLine)) {
+              core.setOutput('should_run', 'false');
+              core.setOutput('windows', 'false');
+              core.setOutput('macos', 'false');
+              core.setOutput('linux', 'false');
+              core.setOutput('linux_targets_json', '[]');
+              return;
+            }
 
-                      const tail = firstLine.replace(/^\/build\b/i, '').trim();
-                      if (tail.length > 0) {
-                        const tokens = tail.split(/\s+/).filter(Boolean);
-                        for (const raw of tokens) {
-                            const lower = raw.toLowerCase();
-                            if (lower === 'windows') {
-                                out.windows = true;
-                            } else if (lower === 'macos' || lower === 'macosx' || lower === 'osx') {
-                                out.macos = true;
-                            } else if (lower.startsWith('linux=')) {
-                                // Keep original token to preserve any casing/symbols after '='
-                                const rhs = raw.slice(raw.indexOf('=') + 1);
-                                const arr = rhs.split(',').map(s => s.trim()).filter(Boolean);
-                                out.linuxTargets.push(...arr);
-                            }
-                        }
-                      }
+            const tail = firstLine.replace(/^\/build\b/i, '').trim();
+            if (tail.length > 0) {
+              const tokens = tail.split(/\s+/).filter(Boolean);
+              for (const raw of tokens) {
+                  const lower = raw.toLowerCase();
+                  if (lower === 'windows') {
+                      out.windows = true;
+                  } else if (lower === 'macos' || lower === 'macosx' || lower === 'osx') {
+                      out.macos = true;
+                  } else if (lower.startsWith('linux=')) {
+                      // Keep original token to preserve any casing/symbols after '='
+                      const rhs = raw.slice(raw.indexOf('=') + 1);
+                      const arr = rhs.split(',').map(s => s.trim()).filter(Boolean);
+                      out.linuxTargets.push(...arr);
+                  }
+              }
+            }
 
-                      const shouldRun = out.windows || out.macos || out.linuxTargets.length > 0;
+            const shouldRun = out.windows || out.macos || out.linuxTargets.length > 0;
 
-                      core.setOutput('should_run', shouldRun ? 'true' : 'false');
-                      core.setOutput('windows', out.windows ? 'true' : 'false');
-                      core.setOutput('macos', out.macos ? 'true' : 'false');
-                      core.setOutput('linux', out.linuxTargets.length > 0 ? 'true' : 'false');
-                      core.setOutput('linux_targets_json', JSON.stringify(out.linuxTargets));
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('windows', out.windows ? 'true' : 'false');
+            core.setOutput('macos', out.macos ? 'true' : 'false');
+            core.setOutput('linux', out.linuxTargets.length > 0 ? 'true' : 'false');
+            core.setOutput('linux_targets_json', JSON.stringify(out.linuxTargets));
 
-    pr-build-get-metadata:
-        name: Get build metadata
-        needs: pr-build-comment
+  pr-build-get-metadata:
+    name: Get build metadata
+    needs: pr-build-comment
+    if: needs.pr-build-comment.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/merge
+
+      - name: Get the versions to use
+        # Look for the default line in the Dockerfile
+        id: set-version
+        run: |
+          VERSION=""
+          if grep -q "ARG TELEMETRY_FORGE_AGENT_VERSION=" Dockerfile.ubi; then
+            VERSION=$(grep "ARG TELEMETRY_FORGE_AGENT_VERSION=" Dockerfile.ubi | cut -d '=' -s -f 2 -)
+          elif grep -q "ARG FLUENTDO_AGENT_VERSION=" Dockerfile.ubi; then
+            VERSION=$(grep "ARG FLUENTDO_AGENT_VERSION=" Dockerfile.ubi | cut -d '=' -s -f 2 -)
+          else
+              echo "ERROR: Could not find either version in Dockerfile."
+              cat Dockerfile.ubi
+              exit 1
+          fi
+          echo "version=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+  pr-build-windows:
+    name: Build Windows
+    needs:
+      - pr-build-comment
+      - pr-build-get-metadata
+    if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-windows == 'true'
+    uses: ./.github/workflows/call-build-windows-packages.yaml
+    with:
+      version: ${{ needs.pr-build-get-metadata.outputs.version }}
+      ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
+
+  pr-build-macos:
+    name: Build macOS
+    needs:
+      - pr-build-comment
+      - pr-build-get-metadata
+    if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-macos == 'true'
+    uses: ./.github/workflows/call-build-macos-packages.yaml
+    with:
+      version: ${{ needs.pr-build-get-metadata.outputs.version }}
+      ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
+
+  pr-build-linux:
+    name: Build Linux
+    needs:
+      - pr-build-comment
+      - pr-build-get-metadata
+    if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-linux == 'true'
+    uses: ./.github/workflows/call-build-linux-packages.yaml
+    with:
+      version: ${{ needs.pr-build-get-metadata.outputs.version }}
+      ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
+      target-matrix: ${{ needs.pr-build-comment.outputs.linux-targets-json }}
+
+  pr-build-comment-response:
+    name: Respond to PR comment
+    if: always()
+    needs:
+      - pr-build-comment
+      - pr-build-windows
+      - pr-build-macos
+      - pr-build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
+      - name: Post results as PR comment
         if: needs.pr-build-comment.outputs.should-run == 'true'
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        outputs:
-            version: ${{ steps.set-version.outputs.version }}
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-
-            - name: Checkout code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  ref: refs/pull/${{ github.event.issue.number }}/merge
-
-            - name: Get the versions to use
-              # Look for the default line in the Dockerfile
-              id: set-version
-              run: |
-                  VERSION=""
-                  if grep -q "ARG TELEMETRY_FORGE_AGENT_VERSION=" Dockerfile.ubi; then
-                    VERSION=$(grep "ARG TELEMETRY_FORGE_AGENT_VERSION=" Dockerfile.ubi | cut -d '=' -s -f 2 -)
-                  elif grep -q "ARG FLUENTDO_AGENT_VERSION=" Dockerfile.ubi; then
-                    VERSION=$(grep "ARG FLUENTDO_AGENT_VERSION=" Dockerfile.ubi | cut -d '=' -s -f 2 -)
-                  else
-                      echo "ERROR: Could not find either version in Dockerfile."
-                      cat Dockerfile.ubi
-                      exit 1
-                  fi
-                  echo "version=$VERSION"
-                  echo "version=$VERSION" >> $GITHUB_OUTPUT
-              shell: bash
-
-    pr-build-windows:
-        name: Build Windows
-        needs:
-            - pr-build-comment
-            - pr-build-get-metadata
-        if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-windows == 'true'
-        uses: ./.github/workflows/call-build-windows-packages.yaml
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.pr-build-comment.outputs.pr-number }}
+          WINDOWS_REQUESTED: ${{ needs.pr-build-comment.outputs.build-windows }}
+          MACOS_REQUESTED: ${{ needs.pr-build-comment.outputs.build-macos }}
+          LINUX_REQUESTED: ${{ needs.pr-build-comment.outputs.build-linux }}
+          LINUX_TARGETS_JSON: ${{ needs.pr-build-comment.outputs.linux-targets-json }}
+          WINDOWS_RESULT: ${{ needs.pr-build-windows.result }}
+          MACOS_RESULT: ${{ needs.pr-build-macos.result }}
+          LINUX_RESULT: ${{ needs.pr-build-linux.result }}
         with:
-            version: ${{ needs.pr-build-get-metadata.outputs.version }}
-            ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
+          script: |
+            const {owner, repo} = context.repo;
+            const run_id = context.runId;
 
-    pr-build-macos:
-        name: Build macOS
-        needs:
-            - pr-build-comment
-            - pr-build-get-metadata
-        if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-macos == 'true'
-        uses: ./.github/workflows/call-build-macos-packages.yaml
-        with:
-            version: ${{ needs.pr-build-get-metadata.outputs.version }}
-            ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
+            // Gather job URLs
+            const byName = {};
+            for await (const { data } of github.paginate.iterator(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id, per_page: 100 }
+            )) {
+              // data is already an array of jobs
+              for (const j of data) {
+                  if (!byName[j.name]) byName[j.name] = j.html_url;
+              }
+            }
 
-    pr-build-linux:
-        name: Build Linux
-        needs:
-            - pr-build-comment
-            - pr-build-get-metadata
-        if: needs.pr-build-comment.outputs.should-run == 'true' && needs.pr-build-comment.outputs.build-linux == 'true'
-        uses: ./.github/workflows/call-build-linux-packages.yaml
-        with:
-            version: ${{ needs.pr-build-get-metadata.outputs.version }}
-            ref: refs/pull/${{ needs.pr-build-comment.outputs.pr-number }}/merge
-            target-matrix: ${{ needs.pr-build-comment.outputs.linux-targets-json }}
+            function statusEmoji(result) {
+                if (!result) return '➖';
+                const r = String(result).toLowerCase();
+                if (r === 'success') return '✅';
+                if (r === 'failure') return '❌';
+                if (r === 'cancelled') return '🛑';
+                if (r === 'skipped') return '⏭️';
+                return '❓';
+            }
 
-    pr-build-comment-response:
-        name: Respond to PR comment
-        if: always()
-        needs:
-            - pr-build-comment
-            - pr-build-windows
-            - pr-build-macos
-            - pr-build-linux
-        runs-on: ubuntu-latest
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+            const requested = {
+                windows: process.env.WINDOWS_REQUESTED === 'true',
+                macos: process.env.MACOS_REQUESTED === 'true',
+                linux: process.env.LINUX_REQUESTED === 'true',
+            };
 
-            - name: Post results as PR comment
-              if: needs.pr-build-comment.outputs.should-run == 'true'
-              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-              env:
-                  PR_NUMBER: ${{ needs.pr-build-comment.outputs.pr-number }}
-                  WINDOWS_REQUESTED: ${{ needs.pr-build-comment.outputs.build-windows }}
-                  MACOS_REQUESTED: ${{ needs.pr-build-comment.outputs.build-macos }}
-                  LINUX_REQUESTED: ${{ needs.pr-build-comment.outputs.build-linux }}
-                  LINUX_TARGETS_JSON: ${{ needs.pr-build-comment.outputs.linux-targets-json }}
-                  WINDOWS_RESULT: ${{ needs.pr-build-windows.result }}
-                  MACOS_RESULT: ${{ needs.pr-build-macos.result }}
-                  LINUX_RESULT: ${{ needs.pr-build-linux.result }}
-              with:
-                  script: |
-                      const {owner, repo} = context.repo;
-                      const run_id = context.runId;
+            const results = {
+                windows: process.env.WINDOWS_RESULT || 'skipped',
+                macos: process.env.MACOS_RESULT || 'skipped',
+                linux: process.env.LINUX_RESULT || 'skipped',
+            };
 
-                      // Gather job URLs
-                      const byName = {};
-                      for await (const { data } of github.paginate.iterator(
-                        github.rest.actions.listJobsForWorkflowRun,
-                        { owner, repo, run_id, per_page: 100 }
-                      )) {
-                        // data is already an array of jobs
-                        for (const j of data) {
-                            if (!byName[j.name]) byName[j.name] = j.html_url;
-                        }
-                      }
+            const linuxTargets = (() => {
+                try { return JSON.parse(process.env.LINUX_TARGETS_JSON || '[]'); }
+                catch { return []; }
+            })();
 
-                      function statusEmoji(result) {
-                          if (!result) return '➖';
-                          const r = String(result).toLowerCase();
-                          if (r === 'success') return '✅';
-                          if (r === 'failure') return '❌';
-                          if (r === 'cancelled') return '🛑';
-                          if (r === 'skipped') return '⏭️';
-                          return '❓';
-                      }
+            const rows = [];
+            if (requested.windows) {
+                const name = 'Build Windows packages';
+                const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
+                rows.push(`- Windows: ${statusEmoji(results.windows)} (${results.windows}) — [Job logs](${url})`);
+            }
+            if (requested.macos) {
+                const name = 'Build macOS packages';
+                const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
+                rows.push(`- macOS: ${statusEmoji(results.macos)} (${results.macos}) — [Job logs](${url})`);
+            }
+            if (requested.linux) {
+                const name = 'Build Linux packages';
+                const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
+                const targetsStr = linuxTargets.length ? '`' + linuxTargets.join('`, `') + '`' : '_none_';
+                rows.push(`- Linux: ${statusEmoji(results.linux)} (${results.linux}) — Targets: ${targetsStr} — [Job logs](${url})`);
+            }
 
-                      const requested = {
-                          windows: process.env.WINDOWS_REQUESTED === 'true',
-                          macos: process.env.MACOS_REQUESTED === 'true',
-                          linux: process.env.LINUX_REQUESTED === 'true',
-                      };
+            const body = [
+                `Build results for /build on PR #${process.env.PR_NUMBER}:`,
+                '',
+                ...rows,
+            ].join('\n');
 
-                      const results = {
-                          windows: process.env.WINDOWS_RESULT || 'skipped',
-                          macos: process.env.MACOS_RESULT || 'skipped',
-                          linux: process.env.LINUX_RESULT || 'skipped',
-                      };
-
-                      const linuxTargets = (() => {
-                          try { return JSON.parse(process.env.LINUX_TARGETS_JSON || '[]'); }
-                          catch { return []; }
-                      })();
-
-                      const rows = [];
-                      if (requested.windows) {
-                          const name = 'Build Windows packages';
-                          const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
-                          rows.push(`- Windows: ${statusEmoji(results.windows)} (${results.windows}) — [Job logs](${url})`);
-                      }
-                      if (requested.macos) {
-                          const name = 'Build macOS packages';
-                          const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
-                          rows.push(`- macOS: ${statusEmoji(results.macos)} (${results.macos}) — [Job logs](${url})`);
-                      }
-                      if (requested.linux) {
-                          const name = 'Build Linux packages';
-                          const url = byName[name] || `${context.serverUrl}/${owner}/${repo}/actions/runs/${run_id}`;
-                          const targetsStr = linuxTargets.length ? '`' + linuxTargets.join('`, `') + '`' : '_none_';
-                          rows.push(`- Linux: ${statusEmoji(results.linux)} (${results.linux}) — Targets: ${targetsStr} — [Job logs](${url})`);
-                      }
-
-                      const body = [
-                          `Build results for /build on PR #${process.env.PR_NUMBER}:`,
-                          '',
-                          ...rows,
-                      ].join('\n');
-
-                      await github.rest.issues.createComment({
-                          owner,
-                          repo,
-                          issue_number: Number(process.env.PR_NUMBER),
-                          body
-                      });
+            await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                body
+            });

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: main
+
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   get-meta:
     name: Get meta information required
@@ -25,6 +30,10 @@ jobs:
     outputs:
       kind-versions: ${{ steps.set-meta.outputs.kind-versions }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,6 +19,10 @@ on:
         type: string
         default: "main"
 
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
   linux-unit-tests:
     name: Run unit tests for ${{ matrix.config.name }}
@@ -44,6 +48,11 @@ jobs:
           #   options: |
           #       SANITIZE_THREAD=On
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -187,6 +196,11 @@ jobs:
     # Add additional jobs here as required that must complete
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -1,101 +1,101 @@
 name: Update LTS branches with changes from main automatically
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - .github/**
-    workflow_dispatch:
-        inputs:
-            dry-run:
-                description: Dry-run the change by doing everything except creating the PR
-                required: false
-                default: true
-                type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - .github/**
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Dry-run the change by doing everything except creating the PR
+        required: false
+        default: true
+        type: boolean
 
 env:
   # Set once from repo variable or override here for testing
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 jobs:
-    lts-branch-updates:
-        name: Update ${{ matrix.branch }} with main changes
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            pull-requests: write
-            id-token: write
-        strategy:
-            matrix:
-                branch:
-                    - release/25.10-lts
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+  lts-branch-updates:
+    name: Update ${{ matrix.branch }} with main changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    strategy:
+      matrix:
+        branch:
+          - release/25.10-lts
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  ref: ${{ matrix.branch }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
 
-            - name: Get Github Actions and other CICD updates
-              run: |
-                  git fetch
-                  git checkout origin/main -- .github/
-              shell: bash
+      - name: Get Github Actions and other CICD updates
+        run: |
+          git fetch
+          git checkout origin/main -- .github/
+        shell: bash
 
-            - name: Debug
-              run: |
-                  git status
-                  git diff
-              shell: bash
+      - name: Debug
+        run: |
+          git status
+          git diff
+        shell: bash
 
-            - name: Authenticate with GCP
-              uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-              with:
-                  workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
-                  service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
-                  create_credentials_file: true
-                  export_environment_variables: true
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+          service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
+          create_credentials_file: true
+          export_environment_variables: true
 
-            - id: get-secrets
-              name: Get secrets from GCP Secret Manager
-              # This step retrieves secrets from GCP Secret Manager and sets them as outputs
-              # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
-              uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
-              with:
-                  secrets: |-
-                      github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
+      - id: get-secrets
+        name: Get secrets from GCP Secret Manager
+        # This step retrieves secrets from GCP Secret Manager and sets them as outputs
+        # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
+        uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
+        with:
+          secrets: |-
+            github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
 
-            - name: Create a PR with the update
-              if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
-              id: cpr
-              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-              with:
-                  commit-message: "ci: update workflows on ${{ matrix.branch }} from main"
-                  signoff: true
-                  branch: ci_update_workflows-${{ matrix.branch }}
-                  delete-branch: true
-                  title: "ci: update workflows on ${{ matrix.branch }}"
-                  token: ${{ steps.get-secrets.outputs.github-pat }}
-                  labels: ci,automerge
-                  body: |
-                      Update workflows automatically on ${{ matrix.branch }}
+      - name: Create a PR with the update
+        if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          commit-message: "ci: update workflows on ${{ matrix.branch }} from main"
+          signoff: true
+          branch: ci_update_workflows-${{ matrix.branch }}
+          delete-branch: true
+          title: "ci: update workflows on ${{ matrix.branch }}"
+          token: ${{ steps.get-secrets.outputs.github-pat }}
+          labels: ci,automerge
+          body: |
+            Update workflows automatically on ${{ matrix.branch }}
 
-                      - Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                      - Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request
-                  draft: false
+            - Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request
+          draft: false
 
-            - name: Check outputs
-              if: ${{ steps.cpr.outputs.pull-request-number }}
-              run: |
-                  echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-                  echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-              shell: bash
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+        shell: bash
 
-            - name: Enable Pull Request Automerge
-              if: ${{ steps.cpr.outputs.pull-request-number }}
-              run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
-              env:
-                  GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -13,6 +13,10 @@ on:
                 default: true
                 type: boolean
 
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
     lts-branch-updates:
         name: Update ${{ matrix.branch }} with main changes
@@ -26,6 +30,11 @@ jobs:
                 branch:
                     - release/25.10-lts
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ matrix.branch }}

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -20,6 +20,11 @@ on:
                 required: false
                 default: true
                 type: boolean
+
+env:
+  # Set once from repo variable or override here for testing
+  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+
 jobs:
     update-version:
         name: Update version
@@ -29,6 +34,10 @@ jobs:
             id-token: write
         runs-on: ubuntu-latest
         steps:
+            - name: Harden the runner
+              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+              with:
+                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0 # Fetch all history including tags

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,204 +1,204 @@
 name: Update version on release
 on:
-    push:
-        tags:
-            - v*
+  push:
+    tags:
+      - v*
 
-    workflow_dispatch:
-        inputs:
-            new-tag:
-                description: The new tag to apply
-                required: true
-                type: string
-            base-branch:
-                description: The base branch to use for the PR
-                required: false
-                default: main
-                type: string
-            dry-run:
-                description: Dry-run the change by doing everything except creating the PR
-                required: false
-                default: true
-                type: boolean
+  workflow_dispatch:
+    inputs:
+      new-tag:
+        description: The new tag to apply
+        required: true
+        type: string
+      base-branch:
+        description: The base branch to use for the PR
+        required: false
+        default: main
+        type: string
+      dry-run:
+        description: Dry-run the change by doing everything except creating the PR
+        required: false
+        default: true
+        type: boolean
 
 env:
   # Set once from repo variable or override here for testing
   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
 jobs:
-    update-version:
-        name: Update version
-        permissions:
-            contents: read
-            pull-requests: write
-            id-token: write
-        runs-on: ubuntu-latest
-        steps:
-            - name: Harden the runner
-              uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-              with:
-                egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  fetch-depth: 0 # Fetch all history including tags
+  update-version:
+    name: Update version
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Fetch all history including tags
 
-            - name: Set manual tag
-              if: github.event_name == 'workflow_dispatch'
-              env:
-                INPUT_TAG: ${{ github.event.inputs.new-tag }}
-              run: |
-                  VERSION=${INPUT_TAG#v}
+      - name: Set manual tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.new-tag }}
+        run: |
+          VERSION=${INPUT_TAG#v}
 
-                  # Validate version format (basic check for x.y.z)
-                  if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    echo "ERROR: Latest tag '$INPUT_TAG' doesn't match expected format vX.Y.Z"
-                    exit 1
-                  fi
+          # Validate version format (basic check for x.y.z)
+          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Latest tag '$INPUT_TAG' doesn't match expected format vX.Y.Z"
+            exit 1
+          fi
 
-                  echo NEW_TAG="v$VERSION"
-                  echo NEW_TAG="v$VERSION" >> $GITHUB_ENV
+          echo NEW_TAG="v$VERSION"
+          echo NEW_TAG="v$VERSION" >> $GITHUB_ENV
 
-                  echo BASE_BRANCH="${{ github.event.inputs.base-branch }}"
-                  echo BASE_BRANCH="${{ github.event.inputs.base-branch }}" >> $GITHUB_ENV
-              shell: bash
+          echo BASE_BRANCH="${{ github.event.inputs.base-branch }}"
+          echo BASE_BRANCH="${{ github.event.inputs.base-branch }}" >> $GITHUB_ENV
+        shell: bash
 
-            - name: Set LTS tag by incrementing current one
-              if: github.event_name != 'workflow_dispatch' && startsWith(github.ref_name, 'v25.10')
-              env:
-                  LATEST_TAG: ${{ github.ref_name }}
-              run: |
-                  # Extract version numbers (remove 'v' prefix)
-                  VERSION=${LATEST_TAG#v}
+      - name: Set LTS tag by incrementing current one
+        if: github.event_name != 'workflow_dispatch' && startsWith(github.ref_name, 'v25.10')
+        env:
+          LATEST_TAG: ${{ github.ref_name }}
+        run: |
+          # Extract version numbers (remove 'v' prefix)
+          VERSION=${LATEST_TAG#v}
 
-                  # Validate version format (basic check for x.y.z)
-                  if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    echo "ERROR: Latest tag '$LATEST_TAG' doesn't match expected format vX.Y.Z"
-                    exit 1
-                  fi
+          # Validate version format (basic check for x.y.z)
+          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Latest tag '$LATEST_TAG' doesn't match expected format vX.Y.Z"
+            exit 1
+          fi
 
-                  # Split version into parts
-                  IFS='.' read -ra VERSION_PARTS <<<"$VERSION"
-                  MAJOR=${VERSION_PARTS[0]}
-                  MINOR=${VERSION_PARTS[1]}
-                  PATCH=${VERSION_PARTS[2]}
+          # Split version into parts
+          IFS='.' read -ra VERSION_PARTS <<<"$VERSION"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
 
-                  echo "MAJOR=$MAJOR"
-                  echo "MINOR=$MINOR"
-                  echo "PATCH=$PATCH"
+          echo "MAJOR=$MAJOR"
+          echo "MINOR=$MINOR"
+          echo "PATCH=$PATCH"
 
-                  # Increment patch version
-                  PATCH=$((PATCH + 1))
+          # Increment patch version
+          PATCH=$((PATCH + 1))
 
-                  GENERATED_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-                  echo NEW_TAG="$GENERATED_VERSION"
-                  echo NEW_TAG="$GENERATED_VERSION" >> $GITHUB_ENV
+          GENERATED_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo NEW_TAG="$GENERATED_VERSION"
+          echo NEW_TAG="$GENERATED_VERSION" >> $GITHUB_ENV
 
-                  BASE_BRANCH="release/${MAJOR}.${MINOR}-lts"
-                  echo "BASE_BRANCH=$BASE_BRANCH"
-                  echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_ENV
-              shell: bash
+          BASE_BRANCH="release/${MAJOR}.${MINOR}-lts"
+          echo "BASE_BRANCH=$BASE_BRANCH"
+          echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_ENV
+        shell: bash
 
-            - name: Fallback to set mainline tag based on date
-              run: |
-                  if [[ -n "${NEW_TAG:-}" ]]; then
-                    echo "Skipping as already have new tag: $NEW_TAG"
-                  else
-                    year=$(date +%y)
-                    month=$(date +%-m)
-                    week=$((($(date +%-d) - 1) / 7 + 1))
+      - name: Fallback to set mainline tag based on date
+        run: |
+          if [[ -n "${NEW_TAG:-}" ]]; then
+            echo "Skipping as already have new tag: $NEW_TAG"
+          else
+            year=$(date +%y)
+            month=$(date +%-m)
+            week=$((($(date +%-d) - 1) / 7 + 1))
 
-                    next_week=$((week + 1))
-                    # Ignore 5 week months
-                    if [ $next_week -gt 4 ]; then
-                      next_week=1
-                      month=$((month + 1))
-                      if [ $month -gt 12 ]; then
-                        month=1
-                        year=$((year + 1))
-                      fi
-                    fi
-                    GENERATED_VERSION="v${year}.${month}.${next_week}"
-                    echo NEW_TAG="$GENERATED_VERSION"
-                    echo NEW_TAG="$GENERATED_VERSION" >> $GITHUB_ENV
-                  fi
+            next_week=$((week + 1))
+            # Ignore 5 week months
+            if [ $next_week -gt 4 ]; then
+              next_week=1
+              month=$((month + 1))
+              if [ $month -gt 12 ]; then
+                month=1
+                year=$((year + 1))
+              fi
+            fi
+            GENERATED_VERSION="v${year}.${month}.${next_week}"
+            echo NEW_TAG="$GENERATED_VERSION"
+            echo NEW_TAG="$GENERATED_VERSION" >> $GITHUB_ENV
+          fi
 
-                  if [[ -z "${BASE_BRANCH:-}" ]]; then
-                    BASE_BRANCH="main"
-                    echo "BASE_BRANCH=$BASE_BRANCH"
-                    echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_ENV
-                  fi
-              shell: bash
+          if [[ -z "${BASE_BRANCH:-}" ]]; then
+            BASE_BRANCH="main"
+            echo "BASE_BRANCH=$BASE_BRANCH"
+            echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_ENV
+          fi
+        shell: bash
 
-            - name: Output tag
-              id: get-version
-              run: |
-                  echo "next_tag=$NEW_TAG"
-                  echo "next_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+      - name: Output tag
+        id: get-version
+        run: |
+          echo "next_tag=$NEW_TAG"
+          echo "next_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
-                  echo "base_branch=$BASE_BRANCH"
-                  echo "base_branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
-              shell: bash
+          echo "base_branch=$BASE_BRANCH"
+          echo "base_branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
+        shell: bash
 
-            - name: Update version to next week
-              run: ./scripts/update-version.sh
-              shell: bash
-              env:
-                  NEW_TELEMETRY_FORGE_AGENT_VERSION: ${{ steps.get-version.outputs.next_tag }}
-                  # Support legacy version variable for backwards compatibility
-                  NEW_FLUENTDO_AGENT_VERSION: ${{ steps.get-version.outputs.next_tag }}
+      - name: Update version to next week
+        run: ./scripts/update-version.sh
+        shell: bash
+        env:
+          NEW_TELEMETRY_FORGE_AGENT_VERSION: ${{ steps.get-version.outputs.next_tag }}
+          # Support legacy version variable for backwards compatibility
+          NEW_FLUENTDO_AGENT_VERSION: ${{ steps.get-version.outputs.next_tag }}
 
-            - name: Debug
-              run: |
-                  git status
-                  git log -n 1
-                  git diff
-              shell: bash
+      - name: Debug
+        run: |
+          git status
+          git log -n 1
+          git diff
+        shell: bash
 
-            - name: Authenticate with GCP
-              uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-              with:
-                  workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
-                  service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
-                  create_credentials_file: true
-                  export_environment_variables: true
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: "projects/841522437311/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+          service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
+          create_credentials_file: true
+          export_environment_variables: true
 
-            - id: get-secrets
-              name: Get secrets from GCP Secret Manager
-              # This step retrieves secrets from GCP Secret Manager and sets them as outputs
-              # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
-              uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
-              with:
-                  secrets: |-
-                      github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
+      - id: get-secrets
+        name: Get secrets from GCP Secret Manager
+        # This step retrieves secrets from GCP Secret Manager and sets them as outputs
+        # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
+        uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3.0.0
+        with:
+          secrets: |-
+            github-pat:projects/626836145334/secrets/GITHUB_CI_PAT
 
-            - name: Create a PR with the update
-              if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
-              id: cpr
-              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-              with:
-                  commit-message: "ci: update to new version ${{ steps.get-version.outputs.next_tag }}"
-                  signoff: true
-                  branch: ci_update-version-${{ steps.get-version.outputs.next_tag }}
-                  delete-branch: true
-                  title: "ci: update version"
-                  token: ${{ steps.get-secrets.outputs.github-pat }}
-                  base: ${{ steps.get-version.outputs.base_branch }}
-                  labels: ci,automerge
-                  body: |
-                      Update version
-                      - Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                      - Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request
-                  draft: false
+      - name: Create a PR with the update
+        if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.dry-run }}
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          commit-message: "ci: update to new version ${{ steps.get-version.outputs.next_tag }}"
+          signoff: true
+          branch: ci_update-version-${{ steps.get-version.outputs.next_tag }}
+          delete-branch: true
+          title: "ci: update version"
+          token: ${{ steps.get-secrets.outputs.github-pat }}
+          base: ${{ steps.get-version.outputs.base_branch }}
+          labels: ci,automerge
+          body: |
+            Update version
+            - Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request
+          draft: false
 
-            - name: Check outputs
-              if: ${{ steps.cpr.outputs.pull-request-number }}
-              run: |
-                  echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-                  echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-              shell: bash
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+        shell: bash
 
-            - name: Enable Pull Request Automerge
-              if: ${{ steps.cpr.outputs.pull-request-number }}
-              run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
-              env:
-                  GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}

--- a/scripts/format-yaml-files.sh
+++ b/scripts/format-yaml-files.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script formats all yaml files in the YAML_DIR directory using the "prettier" npm package.
+
+# This does not work with a symlink to this script
+# SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# See https://stackoverflow.com/a/246128/24637657
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE=$SCRIPT_DIR/$SOURCE
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+REPO_ROOT=${REPO_ROOT:-${SCRIPT_DIR}/..}
+
+YAML_DIR=${YAML_DIR:-$REPO_ROOT/.github/workflows}
+
+# Check if prettier is installed, if not install it globally
+if ! command -v prettier &> /dev/null
+then
+    echo "prettier could not be found, installing it globally..."
+    sudo npm install -g prettier
+fi
+
+# Format all yaml files in the directory
+find "$YAML_DIR" -name "*.yaml" -o -name "*.yml" | while read -r file; do
+    echo "Formatting $file"
+    prettier --write "$file"
+done
+
+# Check if there are any changes after formatting
+if [[ -n $(git status --porcelain) ]]; then
+    echo "The following files were modified after formatting:"
+    git status --porcelain
+    echo "Please review the changes and commit them."
+else
+    echo "All yaml files are properly formatted."
+fi

--- a/scripts/format-yaml-files.sh
+++ b/scripts/format-yaml-files.sh
@@ -37,6 +37,7 @@ if [[ -n $(git status --porcelain) ]]; then
     echo "The following files were modified after formatting:"
     git status --porcelain
     echo "Please review the changes and commit them."
+    exit 1
 else
     echo "All yaml files are properly formatted."
 fi


### PR DESCRIPTION
Resolves #243 by using StepSecurity to initially audit workflow egress traffic.

We use a repo variable to control the behaviour we want from StepSecurity so initially we can just audit the traffic before then enforcing it with no CI change but by modifying the variable.

Added YAML format standardisation for the workflow files including a simple script to do it and check for it in PR linting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds StepSecurity hardening to all GitHub Actions with egress set to audit by default via `STEP_SECURITY_EGRESS_POLICY`. Also standardizes workflow YAML formatting and enforces it with a new PR check. Resolves #243.

- **New Features**
  - Add `step-security/harden-runner@v2.19.0` to all workflows; egress via `STEP_SECURITY_EGRESS_POLICY` (defaults to `audit`).
  - Apply least-privilege defaults (e.g., `permissions: {}`) and explicit job-level scopes.
  - Add `scripts/format-yaml-files.sh` and a `workflow-file-format-pr` job to fail on formatting diffs; uses `prettier`.

- **Migration**
  - Set repo variable `STEP_SECURITY_EGRESS_POLICY` to `audit` (current) or switch to `block` to enforce.
  - To run formatting locally, ensure Node/npm is available; the script installs `prettier` if missing.

<sup>Written for commit 0db7e4ef620606103429df642831e92c6e2a06d0. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/263?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

