### PR TITLE
ci: fixup permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ env:
 # Default to least permissions and then we can add as needed for each job.
 # This is a secure by default approach and also makes it easier to reason
 # about permissions for each job since they are not implicit from the workflow
-permissions: {}
+permissions: read-all
 
 # Cancel any running jobs for PRs on a new commit
 concurrency:


### PR DESCRIPTION
Resolve failures with removing all permissions: https://github.com/telemetryforge/agent/actions/runs/25162611880

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default GitHub Actions workflow permissions to `read-all` to fix build failures caused by an empty `permissions` block. This keeps write access disabled by default while allowing steps like `actions/checkout` to run.

<sup>Written for commit 23659644314f9288717bf3305716dc45eaf013c4. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/266?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

