### PR TITLE
fix: resolve failure with env vars for scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,9 +14,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-env:
-  # Set once from repo variable or override here for testing
-  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+# We cannot have top-level env vars here: https://github.com/ossf/scorecard-action#workflow-restrictions
+# env:
+#   # Set once from repo variable or override here for testing
+#   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 jobs:
   analysis:
     name: Scorecard analysis
@@ -38,7 +39,7 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
       - name: "Checkout code"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Resolves failure seen in https://github.com/telemetryforge/agent/actions/runs/25163915064/job/73765040703, see restrictions at https://github.com/ossf/scorecard-action#workflow-restrictions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSSF Scorecard workflow failures by removing forbidden top‑level env vars and sourcing `STEP_SECURITY_EGRESS_POLICY` from repo `vars` in the `step-security/harden-runner` step, defaulting to `audit`. This aligns with scorecard workflow restrictions and unblocks the analysis job.

- **Bug Fixes**
  - Commented out workflow-level `env`.
  - Set `egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}` in the `step-security/harden-runner` step.

<sup>Written for commit 50ed62609c3ac1770f8a1e505534df6e5a065989. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/267?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

