### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,9 +14,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-env:
-  # Set once from repo variable or override here for testing
-  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
+# We cannot have top-level env vars here: https://github.com/ossf/scorecard-action#workflow-restrictions
+# env:
+#   # Set once from repo variable or override here for testing
+#   STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 jobs:
   analysis:
     name: Scorecard analysis
@@ -38,7 +39,7 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
       - name: "Checkout code"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/25164144772
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Scorecards CI by removing a disallowed top-level env per `ossf/scorecard-action` restrictions and sourcing `STEP_SECURITY_EGRESS_POLICY` from repo vars. This makes `step-security/harden-runner` read the policy via `${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}` and restores the analysis on `release/25.10-lts`.

<sup>Written for commit 289abd20a632fa90020c6a3afb8f81dad3c02593. Summary will update on new commits. <a href="https://cubic.dev/pr/telemetryforge/agent/pull/268?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

