### PR TITLE
feat: set up 26.4 LTS branch and CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -214,6 +214,7 @@ The CI/CD pipeline is designed to:
 **Triggers:**
 
 - Schedule: Mondays at 10:00 UTC (25.10 LTS releases)
+- Schedule: Mondays at 14:00 UTC (26.4 LTS releases)
 - Schedule: Tuesdays at 10:00 UTC (latest releases)
 - Manual workflow dispatch
 

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -214,7 +214,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Override binary name for LTS branch
-        if: contains(github.ref, 'release/25.10-lts') || contains(github.base_ref, 'release/25.10-lts')
+        if: contains(github.ref, 'release/25.10-lts') || contains(github.base_ref, 'release/25.10-lts') || contains(github.ref, 'release/26.4-lts') || contains(github.base_ref, 'release/26.4-lts')
         run: |
           FLUENT_BIT_BINARY="/opt/fluentdo-agent/bin/fluent-bit"
           echo "FLUENT_BIT_BINARY=$FLUENT_BIT_BINARY"

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     # 25.10 releases
     - cron: "0 10 * * 1"
+    # 26.4 releases
+    - cron: "0 14 * * 1"
     # Latest releases
     - cron: "0 10 * * 2"
   workflow_dispatch:
@@ -52,6 +54,13 @@ jobs:
         run: |
           echo "BRANCH=release/25.10-lts" >> $GITHUB_ENV
           echo "TAG_PREFIX=v25.10*" >> $GITHUB_ENV
+        shell: bash
+
+      - name: 26.4 run
+        if: github.event_name == 'schedule' && github.event.schedule=='0 14 * * 1'
+        run: |
+          echo "BRANCH=release/26.4-lts" >> $GITHUB_ENV
+          echo "TAG_PREFIX=v26.4*" >> $GITHUB_ENV
         shell: bash
 
       - name: main run

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         branch:
           - release/25.10-lts
+          - release/26.4-lts
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Set LTS tag by incrementing current one
-        if: github.event_name != 'workflow_dispatch' && startsWith(github.ref_name, 'v25.10')
+        if: github.event_name != 'workflow_dispatch' && (startsWith(github.ref_name, 'v25.10') || startsWith(github.ref_name, 'v26.4'))
         env:
           LATEST_TAG: ${{ github.ref_name }}
         run: |

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ It also has built-in functionality for:
 
 | Version | Release Date | Type | End of Support | Status | Branch |
 | ------- | ------------ | ---- | -------------- | ------ | ------ |
-| **[26.10](https://github.com/orgs/telemetryforge/projects/4)** | Oct 2026 | LTS | Oct 2028 | 🟡 Planned | |
-| **[26.04](https://github.com/orgs/telemetryforge/projects/4)** | Apr 2026 | LTS | Apr 2028 | 🟢 Active | `main` |
+| **[26.10](https://github.com/orgs/telemetryforge/projects/5)** | Oct 2026 | LTS | Oct 2028 | 🟡 `main` | |
+| **[26.04](https://github.com/orgs/telemetryforge/projects/4)** | Apr 2026 | LTS | Apr 2028 | 🟢 Active | `release/26.4-lts` |
 | **[25.10](https://github.com/orgs/telemetryforge/projects/3)** | Oct 2025 | LTS | Oct 2027 | 🟢 Active | `release/25.10-lts` |
-| 25.07 | Jul 2025 | Regular | Jan 2026 | 🟢 Active | |
+| 25.07 | Jul 2025 | Regular | Jan 2026 | 🔴 EOL | |
 
 Main releases follow a date-based format with `Year.Month.Week` forming the version.
 Once it transitions to an LTS release then we maintain the major and minor versions from then on, only incrementing the patch version.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ It also has built-in functionality for:
 
 | Version | Release Date | Type | End of Support | Status | Branch |
 | ------- | ------------ | ---- | -------------- | ------ | ------ |
-| **[26.10](https://github.com/orgs/telemetryforge/projects/5)** | Oct 2026 | LTS | Oct 2028 | 🟡 `main` | |
-| **[26.04](https://github.com/orgs/telemetryforge/projects/4)** | Apr 2026 | LTS | Apr 2028 | 🟢 Active | `release/26.4-lts` |
+| **[26.10](https://github.com/orgs/telemetryforge/projects/5)** | Oct 2026 | LTS | Oct 2028 | 🟡 Planned | `main` |
+| **[26.4](https://github.com/orgs/telemetryforge/projects/4)** | Apr 2026 | LTS | Apr 2028 | 🟢 Active | `release/26.4-lts` |
 | **[25.10](https://github.com/orgs/telemetryforge/projects/3)** | Oct 2025 | LTS | Oct 2027 | 🟢 Active | `release/25.10-lts` |
 | 25.07 | Jul 2025 | Regular | Jan 2026 | 🔴 EOL | |
 


### PR DESCRIPTION
Set up everything required for the latest LTS release using the `release/26.4-lts` branch based off the last `v26.4.4` tag.