### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -214,6 +214,7 @@ The CI/CD pipeline is designed to:
 **Triggers:**
 
 - Schedule: Mondays at 10:00 UTC (25.10 LTS releases)
+- Schedule: Mondays at 14:00 UTC (26.4 LTS releases)
 - Schedule: Tuesdays at 10:00 UTC (latest releases)
 - Manual workflow dispatch
 

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -214,7 +214,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Override binary name for LTS branch
-        if: contains(github.ref, 'release/25.10-lts') || contains(github.base_ref, 'release/25.10-lts')
+        if: contains(github.ref, 'release/25.10-lts') || contains(github.base_ref, 'release/25.10-lts') || contains(github.ref, 'release/26.4-lts') || contains(github.base_ref, 'release/26.4-lts')
         run: |
           FLUENT_BIT_BINARY="/opt/fluentdo-agent/bin/fluent-bit"
           echo "FLUENT_BIT_BINARY=$FLUENT_BIT_BINARY"

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     # 25.10 releases
     - cron: "0 10 * * 1"
+    # 26.4 releases
+    - cron: "0 14 * * 1"
     # Latest releases
     - cron: "0 10 * * 2"
   workflow_dispatch:
@@ -52,6 +54,13 @@ jobs:
         run: |
           echo "BRANCH=release/25.10-lts" >> $GITHUB_ENV
           echo "TAG_PREFIX=v25.10*" >> $GITHUB_ENV
+        shell: bash
+
+      - name: 26.4 run
+        if: github.event_name == 'schedule' && github.event.schedule=='0 14 * * 1'
+        run: |
+          echo "BRANCH=release/26.4-lts" >> $GITHUB_ENV
+          echo "TAG_PREFIX=v26.4*" >> $GITHUB_ENV
         shell: bash
 
       - name: main run

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         branch:
           - release/25.10-lts
+          - release/26.4-lts
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Set LTS tag by incrementing current one
-        if: github.event_name != 'workflow_dispatch' && startsWith(github.ref_name, 'v25.10')
+        if: github.event_name != 'workflow_dispatch' && (startsWith(github.ref_name, 'v25.10') || startsWith(github.ref_name, 'v26.4'))
         env:
           LATEST_TAG: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/25179457444
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request