### PR TITLE
ci: update workflows on release/26.4-lts

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - name: "Checkout Repository"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Dependency Review"
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,12 +42,12 @@ jobs:
           egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -58,7 +58,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -66,6 +66,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Update workflows automatically on release/26.4-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/25251967624
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows on release/26.4-lts to align with main and use the latest action versions. Improves security and reliability for dependency review and OSSF Scorecards.

- **Dependencies**
  - `actions/checkout`: v4.3.1 → v6.0.2
  - `ossf/scorecard-action`: v2.4.0 → v2.4.3
  - `actions/upload-artifact`: v4.6.2 → v7.0.1
  - `github/codeql-action/upload-sarif`: v3.35.2 → v4.35.2

<sup>Written for commit d6d0b8408a0c849fdf99c85e0c678fee6749c7f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

