### PR TITLE
fix: add mising yaml script to 26.4 LTS branch

### DIFF
--- a/scripts/format-yaml-files.sh
+++ b/scripts/format-yaml-files.sh
@@ -19,23 +19,26 @@ REPO_ROOT=${REPO_ROOT:-${SCRIPT_DIR}/..}
 
 YAML_DIR=${YAML_DIR:-$REPO_ROOT/.github/workflows}
 
-# Check if prettier is installed, if not install it globally
-if ! command -v prettier &> /dev/null
-then
-    echo "prettier could not be found, installing it globally..."
-    sudo npm install -g prettier
+if command -v prettier &> /dev/null; then
+    PRETTIER_CMD=(prettier)
+elif command -v npx &> /dev/null; then
+    PRETTIER_CMD=(npx --yes prettier)
+else
+    echo "prettier is not available and npx is not installed."
+    echo "Please install prettier or npm/npx."
+    exit 1
 fi
 
 # Format all yaml files in the directory
-find "$YAML_DIR" -name "*.yaml" -o -name "*.yml" | while read -r file; do
+find "$YAML_DIR" \( -name "*.yaml" -o -name "*.yml" \) | while read -r file; do
     echo "Formatting $file"
-    prettier --write "$file"
+    "${PRETTIER_CMD[@]}" --write "$file"
 done
 
 # Check if there are any changes after formatting
-if [[ -n $(git status --porcelain) ]]; then
+if [[ -n $(git -C "$REPO_ROOT" status --porcelain -- "$YAML_DIR") ]]; then
     echo "The following files were modified after formatting:"
-    git status --porcelain
+    git -C "$REPO_ROOT" status --porcelain -- "$YAML_DIR"
     echo "Please review the changes and commit them."
     exit 1
 else

--- a/scripts/format-yaml-files.sh
+++ b/scripts/format-yaml-files.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # Format all yaml files in the directory
-find "$YAML_DIR" \( -name "*.yaml" -o -name "*.yml" \) | while read -r file; do
+find "$YAML_DIR" -type f \( -name "*.yaml" -o -name "*.yml" \) | while read -r file; do
     echo "Formatting $file"
     "${PRETTIER_CMD[@]}" --write "$file"
 done

--- a/scripts/format-yaml-files.sh
+++ b/scripts/format-yaml-files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script formats all yaml files in the YAML_DIR directory using the "prettier" npm package.
+
+# This does not work with a symlink to this script
+# SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# See https://stackoverflow.com/a/246128/24637657
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE=$SCRIPT_DIR/$SOURCE
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+REPO_ROOT=${REPO_ROOT:-${SCRIPT_DIR}/..}
+
+YAML_DIR=${YAML_DIR:-$REPO_ROOT/.github/workflows}
+
+# Check if prettier is installed, if not install it globally
+if ! command -v prettier &> /dev/null
+then
+    echo "prettier could not be found, installing it globally..."
+    sudo npm install -g prettier
+fi
+
+# Format all yaml files in the directory
+find "$YAML_DIR" -name "*.yaml" -o -name "*.yml" | while read -r file; do
+    echo "Formatting $file"
+    prettier --write "$file"
+done
+
+# Check if there are any changes after formatting
+if [[ -n $(git status --porcelain) ]]; then
+    echo "The following files were modified after formatting:"
+    git status --porcelain
+    echo "Please review the changes and commit them."
+    exit 1
+else
+    echo "All yaml files are properly formatted."
+fi


### PR DESCRIPTION
Adds missing script to resolve errors like https://github.com/telemetryforge/agent/actions/runs/25426842070/job/74582436148

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/format-yaml-files.sh` to format GitHub Actions workflow YAML with `prettier`, fixing CI failures on the 26.4 LTS branch.

- **Bug Fixes**
  - Formats `.github/workflows` YAML files via `prettier` (files only).
  - Uses `prettier` if available or `npx prettier`; no global/privileged install.
  - Exits non-zero when formatting changes are made to prompt a commit.
  - Scopes dirty check to workflow YAML only; supports `REPO_ROOT` and `YAML_DIR` overrides.

<sup>Written for commit 19bcda474f7a5541ee559ed7e69da6fea3d0788e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

