### PR TITLE
feat: add support for Ubuntu 26.04

### DIFF
--- a/build-config.json
+++ b/build-config.json
@@ -39,6 +39,8 @@
     "ubuntu/22.04.arm64v8",
     "ubuntu/24.04",
     "ubuntu/24.04.arm64v8",
+    "ubuntu/26.04",
+    "ubuntu/26.04.arm64v8",
     "suse/15"
   ],
   "release": {
@@ -53,6 +55,7 @@
       "debian/trixie",
       "ubuntu/22.04",
       "ubuntu/24.04",
+      "ubuntu/26.04",
       "suse/15"
     ]
   },

--- a/source/lib/rocksdb/db/blob/blob_file_meta.h
+++ b/source/lib/rocksdb/db/blob/blob_file_meta.h
@@ -11,6 +11,9 @@
 #include <string>
 #include <unordered_set>
 
+// Required for more recent GCC 15
+#include <cstdint>
+
 #include "rocksdb/rocksdb_namespace.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/source/packaging/distros/ubuntu/Dockerfile
+++ b/source/packaging/distros/ubuntu/Dockerfile
@@ -206,7 +206,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2204-${CAC
 RUN mkdir -p "${CMAKE_HOME}" && \
     cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
@@ -236,7 +236,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2204-arm64
 RUN mkdir -p "${CMAKE_HOME}" && \
     cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
@@ -264,7 +264,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2404-${CAC
 RUN mkdir -p "${CMAKE_HOME}" && \
     cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
@@ -294,7 +294,65 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2404-arm64
 RUN mkdir -p "${CMAKE_HOME}" && \
     cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+# ubuntu/26.04 base image
+FROM ubuntu:26.04 AS ubuntu-26.04-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+ARG CACHE_ID
+# hadolint ignore=DL3008,DL3015
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2404-${CACHE_ID} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=ubuntu-2404-${CACHE_ID} \
+    apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    make bash wget unzip nano vim valgrind dh-make flex bison \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev libgit2-dev \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release
+
+# hadolint ignore=DL4001,DL4006
+RUN mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+# ubuntu/26.04.arm64v8 base image
+FROM arm64v8/ubuntu:24.04 AS ubuntu-26.04.arm64v8-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+ARG CACHE_ID
+# hadolint ignore=DL3008,DL3015
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ubuntu-2404-arm64-${CACHE_ID} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=ubuntu-2404-arm64-${CACHE_ID} \
+    apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    make bash wget unzip nano vim valgrind dh-make flex bison \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev libgit2-dev \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release
+
+# hadolint ignore=DL4001,DL4006
+RUN mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jsSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 

--- a/source/packaging/distros/ubuntu/Dockerfile
+++ b/source/packaging/distros/ubuntu/Dockerfile
@@ -327,7 +327,7 @@ RUN mkdir -p "${CMAKE_HOME}" && \
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
 # ubuntu/26.04.arm64v8 base image
-FROM arm64v8/ubuntu:24.04 AS ubuntu-26.04.arm64v8-base
+FROM arm64v8/ubuntu:26.04 AS ubuntu-26.04.arm64v8-base
 ENV DEBIAN_FRONTEND="noninteractive" \
     CMAKE_HOME="/opt/cmake"
 


### PR DESCRIPTION
Mirrors upstream PR (created by myself): https://github.com/fluent/fluent-bit/pull/11802

Replicated https://github.com/facebook/rocksdb/pull/13579 to resolve failures on GCC 15 with missing `#include <cstdint>` due to https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds packaging support for Ubuntu 26.04 (amd64 and arm64) and includes it in release targets. Also fixes GCC 15 builds and removes the insecure curl flag in CMake downloads.

- **New Features**
  - Added `ubuntu/26.04` and `ubuntu/26.04.arm64v8` to build targets; added `ubuntu/26.04` to release list.
  - Added Docker base stages for `ubuntu/26.04` and `ubuntu/26.04.arm64v8` with required deps and CMake.

- **Bug Fixes**
  - Corrected Docker base stage reference for Ubuntu 26.04 builds.
  - Fixed RocksDB build on GCC 15 by including `<cstdint>`.

<sup>Written for commit 26aa2839deb6813d9d9429da15a25b96eea77fdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

