### PR TITLE
ci: update workflows on release/26.4-lts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     groups:
       github-actions:
         patterns:
           - "*"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -17,3 +19,5 @@ updates:
           - "*"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       oss-version: ${{ steps.set-oss-version.outputs.oss-version }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -317,7 +317,7 @@ jobs:
       TAG: ${{ needs.build-image.outputs.version }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ${{ (contains(matrix.platform, 'arm') && inputs.arm-runner-label) || inputs.amd-runner-label }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -236,7 +236,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -312,7 +312,7 @@ jobs:
       IMAGE: ${{ needs.build-container-image-manifest.outputs.tag }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -73,7 +73,7 @@ jobs:
         distro: ${{ fromJson(inputs.target-matrix) }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-build-macos-packages.yaml
+++ b/.github/workflows/call-build-macos-packages.yaml
@@ -42,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-build-windows-packages.yaml
+++ b/.github/workflows/call-build-windows-packages.yaml
@@ -47,7 +47,7 @@ jobs:
       VCPKG_LIBRARY_LINKAGE: static
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -115,17 +115,24 @@ jobs:
             ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-installed-
           enableCrossOsArchive: false
 
-      - name: Build openssl with vcpkg
+      - name: Install openssl with vcpkg
         run: |
           C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
 
-      - name: Build libyaml with vcpkg
+      - name: Install libyaml with vcpkg
         run: |
           C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
 
-      - name: Build libgit2 with vcpkg
+      - name: Install zlib with vcpkg
+        run: |
+          C:\vcpkg\vcpkg install --recurse zlib --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
+
+      - name: Install libgit2 with vcpkg
+        # Note that this has a dependency on zlib we need to satisfy, ideally from our vendored version
+        # but that is not possible in this case without building from source.
         run: |
           C:\vcpkg\vcpkg install --recurse libgit2 --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
@@ -150,10 +157,12 @@ jobs:
           key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
           enableCrossOsArchive: false
 
-      - name: Build hardened Fluent Bit packages
+      - name: Configure build
         run: |
           cmake -G "NMake Makefiles" `
             -DCMAKE_VERBOSE_MAKEFILE=On `
+            -DCMAKE_TOOLCHAIN_FILE='C:\vcpkg\scripts\buildsystems\vcpkg.cmake' `
+            -DVCPKG_TARGET_TRIPLET='${{ matrix.config.vcpkg_triplet }}' `
             -DOPENSSL_ROOT_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' `
             ${{ matrix.config.cmake_additional_opt }} `
             -DFLB_LIBYAML_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' `
@@ -193,9 +202,25 @@ jobs:
             -DFLB_TRACE=Off `
             -DFLB_CHUNK_TRACE=Off `
             ../
+        working-directory: source/build
+
+      - name: Build hardened Fluent Bit packages
+        run: |
           cmake --build .
           cpack
         working-directory: source/build
+
+      - name: Debug build output
+        if: always()
+        continue-on-error: true
+        # Find all files in the build output directory and print them to the logs for debugging purposes
+        run: |
+          Get-ChildItem -Path source/build/**/*.log -Recurse | ForEach-Object {
+            Write-Host "Contents of $($_.FullName):"
+            Get-Content $_.FullName
+            Write-Host "End of $($_.FullName)"
+          }
+        shell: pwsh
 
       - name: Upload build packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/call-publish-release-images.yaml
+++ b/.github/workflows/call-publish-release-images.yaml
@@ -30,7 +30,7 @@ jobs:
       TAG: ${{ inputs.version }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -89,7 +89,7 @@ jobs:
       - promote-ghcr-images
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-test-containers-k8s.yaml
+++ b/.github/workflows/call-test-containers-k8s.yaml
@@ -41,7 +41,7 @@ jobs:
       FLUENTDO_AGENT_TAG: ${{ inputs.image-tag }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-test-containers.yaml
+++ b/.github/workflows/call-test-containers.yaml
@@ -34,7 +34,7 @@ jobs:
       kind-versions: ${{ steps.set-meta.outputs.kind-versions }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -65,7 +65,7 @@ jobs:
       packages: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -127,7 +127,7 @@ jobs:
       packages: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -165,7 +165,7 @@ jobs:
       packages: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -242,7 +242,7 @@ jobs:
       - test-bats-container
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -55,7 +55,7 @@ jobs:
       linux-test-targets: ${{ steps.get_matrix.outputs.linux_test_targets }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -125,7 +125,7 @@ jobs:
         config: ${{ fromJson(needs.call-test-packages-get-meta.outputs.linux-test-targets) }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -203,7 +203,7 @@ jobs:
       FLUENT_BIT_BINARY: ${{ matrix.binary }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/cron-auto-release.yaml
+++ b/.github/workflows/cron-auto-release.yaml
@@ -2,11 +2,11 @@ name: Tag a new release
 on:
   schedule:
     # 25.10 releases
-    - cron: "0 10 * * 1"
+    - cron: "0 14 1 * *"
     # 26.4 releases
-    - cron: "0 14 * * 1"
+    - cron: "0 14 15 * *"
     # Latest releases
-    - cron: "0 10 * * 2"
+    - cron: "0 10 * * 1"
   workflow_dispatch:
     inputs:
       branch:
@@ -43,28 +43,28 @@ jobs:
       prefix: ${{ steps.detect-prefix.outputs.prefix || 'v*' }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 25.10 run
-        if: github.event_name == 'schedule' && github.event.schedule=='0 10 * * 1'
+        if: github.event_name == 'schedule' && github.event.schedule=='0 14 1 * *'
         run: |
           echo "BRANCH=release/25.10-lts" >> $GITHUB_ENV
           echo "TAG_PREFIX=v25.10*" >> $GITHUB_ENV
         shell: bash
 
       - name: 26.4 run
-        if: github.event_name == 'schedule' && github.event.schedule=='0 14 * * 1'
+        if: github.event_name == 'schedule' && github.event.schedule=='0 14 15 * *'
         run: |
           echo "BRANCH=release/26.4-lts" >> $GITHUB_ENV
           echo "TAG_PREFIX=v26.4*" >> $GITHUB_ENV
         shell: bash
 
       - name: main run
-        if: github.event_name == 'schedule' && github.event.schedule=='0 10 * * 2'
+        if: github.event_name == 'schedule' && github.event.schedule=='0 10 * * 1'
         run: |
           echo "BRANCH=main" >> $GITHUB_ENV
           echo "TAG_PREFIX=v*" >> $GITHUB_ENV
@@ -119,7 +119,7 @@ jobs:
       tag_name: ${{ steps.tag_name.outputs.tag_name }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/lint-packages.yaml
+++ b/.github/workflows/lint-packages.yaml
@@ -32,7 +32,7 @@ jobs:
     name: PR - Lintian (Package changes)
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,10 +24,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
         # Ignores do not work: https://github.com/reviewdog/action-hadolint/issues/35 is resolved
       - uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407 # v1.50.5
 
@@ -40,10 +42,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
           reporter: github-pr-review
@@ -61,10 +65,12 @@ jobs:
     name: PR - Actionlint
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -76,10 +82,12 @@ jobs:
     name: PR - Workflow file format
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: ./scripts/format-yaml-files.sh
         shell: bash
 
@@ -90,7 +98,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
@@ -137,11 +145,41 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
           skip_push: "true"
           review: "true"
+
+  zizmor-lint:
+    runs-on: ubuntu-latest
+    name: PR - Zizmor
+    # https://docs.zizmor.sh/
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      # contents: read         # Only needed for private repos. Needed to clone the repo.
+      # actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
+        with:
+          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # We only want to scan our workflows, no other included source
+          input: |
+            ".github/"
+          # Upload to security tab in GitHub, requires permissions: security-events: write
+          # Note this does not fail the workflow, just uploads the results to the security tab in GitHub
+          advanced-security: true
+          min-severity: "medium"

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -40,7 +40,7 @@ jobs:
       linux-targets-json: ${{ steps.parse.outputs.linux_targets_json }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - name: Log useful info
@@ -115,7 +115,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       kind-versions: ${{ steps.set-meta.outputs.kind-versions }}
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - name: Checkout code

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,8 +38,11 @@ jobs:
               SANITIZE_ADDRESS=On
               SANITIZE_UNDEFINED=On
           - name: coverage
+            # Coverage needs more stack for some of the tests
+            # https://github.com/fluent/fluent-bit/pull/11614
             options: |
               FLB_COVERAGE=On
+              FLB_CORO_STACK_SIZE=4194304
           # Uncomment to enable additional config as needed
           # - name: memory
           #   options: |
@@ -49,7 +52,7 @@ jobs:
           #       SANITIZE_THREAD=On
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 
@@ -197,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/update-lts-branches.yaml
+++ b/.github/workflows/update-lts-branches.yaml
@@ -35,7 +35,7 @@ jobs:
           - release/26.4-lts
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
 

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
         with:
           egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Update workflows automatically on release/26.4-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/26290641349
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request