### PR TITLE
fix: ensure we build the agent registration plugin

### DIFF
--- a/source/cmake/plugins_options.cmake
+++ b/source/cmake/plugins_options.cmake
@@ -11,11 +11,11 @@ option(FLB_MINIMAL "Enable minimal build configuration" No)
 
 # Custom Plugins
 # ===============
-DEFINE_OPTION(FLB_CUSTOM_TELEMETRY_FORGE "Enable Telemetry Forge custom plugin" ON)
+DEFINE_OPTION(FLB_CUSTOM_TELEMETRYFORGE "Enable Telemetry Forge custom plugin" ON)
 
 # Inputs (sources, data collectors)
 # =================================
-DEFINE_OPTION(FLB_IN_TELEMETRY_FORGE "Enable Telemetry Forge input plugin" ON)
+DEFINE_OPTION(FLB_IN_TELEMETRYFORGE "Enable Telemetry Forge input plugin" ON)
 # =================================
 DEFINE_OPTION(FLB_IN_BLOB                     "Enable Blob input plugin"                     ON)
 DEFINE_OPTION(FLB_IN_CALYPTIA_FLEET           "Enable Calyptia Fleet input plugin"           OFF)

--- a/testing/bats/tests/functional/plugins/verify-custom-plugins.bats
+++ b/testing/bats/tests/functional/plugins/verify-custom-plugins.bats
@@ -24,6 +24,15 @@ teardown() {
     refute_output --partial "[error]"
 }
 
+@test "verify custom telemetryforge plugin exists" {
+    run "$FLUENT_BIT_BINARY" --help
+    assert_success
+    assert_output --partial "telemetryforge"
+    run "$FLUENT_BIT_BINARY" -C "telemetryforge" --help
+    assert_success
+    refute_output --partial "[error]"
+}
+
 # Processors cannot be individually queried unfortunately like custom plugins so we just check for their existence in the help output
 @test "verify log_sampling processor exists" {
     PLUGIN_NAME="log_sampling"


### PR DESCRIPTION
During renaming from FluentDo to Telemetry Forge we incorrectly changed the plugin name for CMake options so it was not being built.

Backport to LTS 26.4, previous LTS 25.10 was prior to the rename so is fine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CMake option names so the Telemetry Forge agent registration plugin builds and shows up in help. Add a functional test that checks `telemetryforge` is listed and can be queried. Backport to LTS 26.4.

- Bug Fixes
  - Renamed CMake options to `FLB_CUSTOM_TELEMETRYFORGE` and `FLB_IN_TELEMETRYFORGE` to match the plugin ID.
  - Added Bats test to assert `telemetryforge` appears in `--help` and `-C telemetryforge --help` succeeds without errors.

<sup>Written for commit 36bfb7c7c231c1a5c5cab09a4f1d7ca20d17a663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/telemetryforge/agent/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

