### PR TITLE
ci: update workflows on release/25.10-lts

### DIFF
--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -105,7 +105,7 @@ jobs:
       # Must be removed on Namespace runners
       - name: Set up QEMU
         if: ${{ !contains( runner.name, 'nsc-' ) }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: ${{ !contains( runner.name, 'nsc-' ) }}

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -98,7 +98,7 @@ jobs:
       # Must be removed on Namespace runners
       - name: Set up QEMU
         if: ${{ !contains( runner.name, 'nsc-' ) }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: ${{ !contains( runner.name, 'nsc-' ) }}

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -145,7 +145,7 @@ jobs:
       # Must be removed on Namespace runners
       - name: Set up QEMU
         if: ${{ !contains( runner.name, 'nsc-' ) }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: ${{ !contains( runner.name, 'nsc-' ) }}
@@ -228,7 +228,7 @@ jobs:
       # Must be removed on Namespace runners
       - name: Set up QEMU
         if: ${{ !contains( runner.name, 'nsc-' ) }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: ${{ !contains( runner.name, 'nsc-' ) }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:
           skip_push: "true"
           review: "true"


### PR DESCRIPTION
Update workflows automatically on release/25.10-lts

- Created by https://github.com/telemetryforge/agent/actions/runs/26942235095
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows on `release/25.10-lts` to bump pinned GitHub Actions for stability and parity with `main`. Upgrades `docker/setup-qemu-action` to v4.1.0 and `suzuki-shunsuke/pinact-action` to v3.0.0.

- **Dependencies**
  - `docker/setup-qemu-action`: v4.0.0 → v4.1.0 (containers, Linux packages, test packages)
  - `suzuki-shunsuke/pinact-action`: v2.0.0 → v3.0.0 (lint)

<sup>Written for commit 9fe0a914d9368693b44099516ea9567ceb6df2db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/telemetryforge/agent/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

