### PR TITLE
fix: ensure we build the agent registration plugin

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,8 +1,11 @@
+# syntax=docker/dockerfile:1
+
 FROM registry.access.redhat.com/ubi9:9.7 AS base-builder
 
 # hadolint ignore=DL3041
 RUN dnf update -y && \
-    dnf install -y cmake3 diffutils gcc gcc-c++ git m4 make openssl-devel patch systemd-devel tar unzip libyaml-devel cyrus-sasl-devel zlib-devel pcre2-devel && \
+    dnf install -y cmake3 diffutils gcc gcc-c++ git m4 make openssl-devel patch systemd-devel tar unzip \
+    libyaml-devel cyrus-sasl-devel zlib-devel pcre2-devel libzstd-devel && \
     dnf clean all && rm -rf /var/cache/dnf
 
 # Provide the dependencies for record accessor built from source
@@ -28,6 +31,7 @@ RUN curl -LO https://www.libssh2.org/download/libssh2-${LIBSSH2_VER}.tar.gz && \
 WORKDIR /tmp/libssh2-${LIBSSH2_VER}
 RUN ./configure --with-openssl --prefix=/usr/local --disable-examples-build && \
     make -j "$(getconf _NPROCESSORS_ONLN)" && make install && \
+    echo "/usr/local/lib" > /etc/ld.so.conf.d/libssh2.conf && \
     ldconfig
 
 # Build libgit2 from source
@@ -57,7 +61,7 @@ ARG TELEMETRY_FORGE_AGENT_VERSION=26.4.8
 ENV TELEMETRY_FORGE_AGENT_VERSION=${TELEMETRY_FORGE_AGENT_VERSION}
 
 # Build metadata
-ARG TELEMETRY_FORGE_AGENT_DISTRO=ubi/9.5
+ARG TELEMETRY_FORGE_AGENT_DISTRO=ubi/9.7
 ENV TELEMETRY_FORGE_AGENT_DISTRO=$TELEMETRY_FORGE_AGENT_DISTRO
 
 ARG TELEMETRY_FORGE_AGENT_PACKAGE_TYPE=CONTAINER
@@ -95,6 +99,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release \
     -DTELEMETRY_FORGE_AGENT_VERSION="$TELEMETRY_FORGE_AGENT_VERSION" \
     -DFLB_LOG_NO_CONTROL_CHARS=On \
     -DFLB_CORO_STACK_SIZE=131072 \
+    -DFLB_PREFER_SYSTEM_LIB_ZSTD=On \
     ${CMAKE_EXTRA_ARGS} \
     ..
 
@@ -111,7 +116,7 @@ RUN [ -n "$MAKE_EXTRA_ARGS" ] && make ${MAKE_EXTRA_ARGS} || make -j "$(getconf _
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS production
 
 # hadolint ignore=DL3041
-RUN microdnf update -y && microdnf install -y openssl libyaml cyrus-sasl && microdnf clean all
+RUN microdnf update -y && microdnf install -y openssl libyaml cyrus-sasl zstd && microdnf clean all
 
 EXPOSE 2020
 
@@ -127,7 +132,7 @@ COPY --from=builder /fluent-bit /fluent-bit
 # Copy libgit2 and libssh2 runtime libraries from builder
 COPY --from=builder /usr/local/lib64/libgit2.so.*.*.* /usr/local/lib64/
 COPY --from=builder /usr/local/lib/libssh2.so.*.*.* /usr/local/lib/
-# Set up ldconfig and symlinks for the copied libraries
+# Set up ldconfig and symlinks for the libraries
 RUN echo "/usr/local/lib64" > /etc/ld.so.conf.d/local-libs.conf && \
     echo "/usr/local/lib" >> /etc/ld.so.conf.d/local-libs.conf && \
     ldconfig
@@ -170,8 +175,9 @@ FROM production AS test
 USER root
 
 # We need find and ps/pkill for BATS
+# We need git for the git_config plugin tests
 # hadolint ignore=DL3041
-RUN microdnf update -y && microdnf install -y findutils procps && microdnf clean all
+RUN microdnf update -y && microdnf install -y findutils procps git && microdnf clean all
 
 COPY --from=bats /opt/bats /opt/bats
 RUN /opt/bats/install.sh /usr/local

--- a/source/cmake/plugins_options.cmake
+++ b/source/cmake/plugins_options.cmake
@@ -11,11 +11,11 @@ option(FLB_MINIMAL "Enable minimal build configuration" No)
 
 # Custom Plugins
 # ===============
-DEFINE_OPTION(FLB_CUSTOM_TELEMETRY_FORGE "Enable Telemetry Forge custom plugin" ON)
+DEFINE_OPTION(FLB_CUSTOM_TELEMETRYFORGE "Enable Telemetry Forge custom plugin" ON)
 
 # Inputs (sources, data collectors)
 # =================================
-DEFINE_OPTION(FLB_IN_TELEMETRY_FORGE "Enable Telemetry Forge input plugin" ON)
+DEFINE_OPTION(FLB_IN_TELEMETRYFORGE "Enable Telemetry Forge input plugin" ON)
 # =================================
 DEFINE_OPTION(FLB_IN_BLOB                     "Enable Blob input plugin"                     ON)
 DEFINE_OPTION(FLB_IN_CALYPTIA_FLEET           "Enable Calyptia Fleet input plugin"           OFF)

--- a/testing/Dockerfile.bats
+++ b/testing/Dockerfile.bats
@@ -8,6 +8,26 @@ FROM ${BASE_BUILDER} AS test
 COPY --from=bats /opt/bats /opt/bats
 RUN /opt/bats/install.sh /usr/local
 
+# Install git for testing the git config plugin
+RUN if ! command -v git &>/dev/null; then \
+        if command -v yum &>/dev/null; then \
+            yum install -y git; \
+        elif command -v microdnf &>/dev/null; then \
+            microdnf install -y git; \
+        elif command -v dnf &>/dev/null; then \
+            dnf install -y git; \
+        elif command -v apk &>/dev/null; then \
+            apk add --no-cache git; \
+        elif command -v zypper &>/dev/null; then \
+            zypper install -y git; \
+        elif command -v apt-get &>/dev/null; then \
+            apt-get update && apt-get install -y git; \
+        else \
+            echo "ERROR: unable to install git"; \
+            exit 1; \
+        fi \
+    fi
+
 COPY testing/ /testing/
 
 # Put packages to install here

--- a/testing/bats/helpers/test-helpers.bash
+++ b/testing/bats/helpers/test-helpers.bash
@@ -228,3 +228,86 @@ function helmTeardown() {
     fi
 	export DETIK_CLIENT_NAMESPACE=''
 }
+
+# Starts fluent-bit in the background, redirecting output to a temp file
+# Sets FB_PID and FB_LOG as global variables
+function startFluentBit() {
+    FB_LOG=$(mktemp)
+    "$FLUENT_BIT_BINARY" "$@" > "$FB_LOG" 2>&1 &
+    FB_PID=$!
+	echo "Started $FLUENT_BIT_BINARY with PID $FB_PID and log file $FB_LOG: $*"
+}
+
+# After a successful match, call this to record the current log position.
+# Future calls to waitForOutput can then only check for new output since this point
+function markLogPosition() {
+	if [[ -z "${FB_LOG:-}" ]]; then
+		fail "FB_LOG not set, cannot mark log position"
+	fi
+	FB_LOG_OFFSET=$(wc -c < "$FB_LOG")
+}
+
+function resetLogPosition() {
+	unset FB_LOG_OFFSET
+}
+
+# Waits for a specific pattern to appear in the log
+# Usage: waitForOutput "pattern" [timeout_seconds]
+# Default timeout is 30 seconds
+function waitForOutputFromOffset() {
+    local pattern="$1"
+    local timeout="${2:-30}"
+    local offset="${3:-0}"
+    local elapsed=0
+    local interval=1
+
+	if [[ -z "${FB_LOG:-}" ]]; then
+		fail "FB_LOG not set, cannot wait for output"
+	fi
+
+	if [[ -z "${FB_PID:-}" ]]; then
+		fail "FB_PID not set, cannot wait for output"
+	fi
+
+    while (( elapsed < timeout )); do
+        if tail -c +"$((offset + 1))" "$FB_LOG" 2>/dev/null | grep -qE "$pattern"; then
+            return 0
+        fi
+
+        if ! kill -0 "$FB_PID" 2>/dev/null; then
+            cat "$FB_LOG"
+            fail "$FLUENT_BIT_BINARY exited unexpectedly."
+            return 1
+        fi
+
+        sleep "$interval"
+        elapsed=$(( elapsed + interval ))
+    done
+
+    echo "Log contents (from offset ${offset}):"
+    tail -c +"$((offset + 1))" "$FB_LOG"
+    fail "Timed out after ${timeout}s waiting for new pattern: $pattern"
+	return 1
+}
+
+# Wait for a specific pattern to appear in the log since the start of the log (i.e. not just new output since the last marked position)
+function waitForOutput() {
+	waitForOutputFromOffset "$1" "$2" 0
+}
+
+# Wait for a specific pattern to appear in the log since the last marked position
+function waitForNewOutput() {
+	waitForOutputFromOffset "$1" "$2" "${FB_LOG_OFFSET:-0}"
+}
+
+# Cleanup function to kill fluent-bit and remove temp files
+function stopFluentBit() {
+    if [[ -n "${FB_PID:-}" ]] && kill -0 "$FB_PID" 2>/dev/null; then
+        kill -9 "$FB_PID"
+        wait "$FB_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${FB_LOG:-}" ]]; then
+        rm -f "$FB_LOG"
+    fi
+	resetLogPosition
+}

--- a/testing/bats/tests/functional/plugins/git_config/resources/fluent-bit-no-exit.yaml
+++ b/testing/bats/tests/functional/plugins/git_config/resources/fluent-bit-no-exit.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+
+pipeline:
+  inputs:
+    - name: dummy
+      dummy: '{"message": "Dummy initial message"}'
+      alias: input_dummy
+
+  outputs:
+    - name: stdout
+      match: '*'
+      alias: output_stdout

--- a/testing/bats/tests/functional/plugins/git_config/resources/fluent-bit.yaml
+++ b/testing/bats/tests/functional/plugins/git_config/resources/fluent-bit.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+
+pipeline:
+  inputs:
+    - name: dummy
+      dummy: '{"message": "Switched to updated configuration", "sha": "${GIT_SHA}"}'
+      alias: input_dummy
+
+  outputs:
+    - name: stdout
+      match: '*'
+      alias: output_stdout
+    - name: exit
+      match: '*'
+      # Exit after processing 2 records to ensure the test completes in a reasonable time frame
+      record_count: 2
+      alias: output_exit

--- a/testing/bats/tests/functional/plugins/git_config/resources/initial-fluent-bit-no-exit.yaml
+++ b/testing/bats/tests/functional/plugins/git_config/resources/initial-fluent-bit-no-exit.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: debug
+
+customs:
+  - name: git_config
+    # We use a local git repository for testing to keep things simple and consistent.
+    repo: file://${GIT_REPO_PATH}
+    # We may need to adjust this per-PR appropriately to ensure we are testing the correct branch/PR
+    ref: ${GIT_SHA}
+    path: fluent-bit-no-exit.yaml
+    # Do not poll too fast as we still need to apply the commit between polls
+    poll_interval: 10
+    # Use a different config directory to prevent conflicts with other tests
+    # See https://github.com/telemetryforge/agent/issues/274
+    config_dir: ${BATS_TEST_TMPDIR}/tmp/fluent-bit

--- a/testing/bats/tests/functional/plugins/git_config/resources/initial-fluent-bit.yaml
+++ b/testing/bats/tests/functional/plugins/git_config/resources/initial-fluent-bit.yaml
@@ -1,0 +1,30 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: debug
+
+customs:
+  - name: git_config
+    # We use a local git repository for testing to keep things simple and consistent.
+    repo: file://${GIT_REPO_PATH}
+    # We may need to adjust this per-PR appropriately to ensure we are testing the correct branch/PR
+    ref: ${GIT_SHA}
+    path: fluent-bit.yaml
+    # Do not poll too fast as we still need to apply the commit between polls
+    poll_interval: 10
+    # Use a different config directory to prevent conflicts with other tests
+    # See https://github.com/telemetryforge/agent/issues/274
+    config_dir: ${BATS_TEST_TMPDIR}/tmp/fluent-bit
+
+# Fall back to ensure we exit after 60 seconds in case the plugin doesn't work as expected to prevent hanging the test indefinitely
+# See https://github.com/telemetryforge/agent/issues/272 to remove this later once implemented.
+pipeline:
+  inputs:
+    - name: dummy
+      dummy: '{"message": "Ignored"}'
+      alias: input_dummy_ignored
+  outputs:
+    - name: exit
+      match: '*'
+      time_count: 60
+      alias: output_exit_fallback

--- a/testing/bats/tests/functional/plugins/git_config/verify-git-config-plugin.bats
+++ b/testing/bats/tests/functional/plugins/git_config/verify-git-config-plugin.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+load "$HELPERS_ROOT/test-helpers.bash"
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_FILE_ROOT FLUENT_BIT_BINARY
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+load "$BATS_FILE_ROOT/load.bash"
+
+# bats file_tags=functional
+teardown() {
+    if [[ -n "${SKIP_TEARDOWN:-}" ]]; then
+        echo "Skipping teardown"
+    else
+        # Stop Fluent Bit after each test
+        stopFluentBit
+    fi
+}
+
+# We are not testing libgit here but just the implementation of our plugin.
+#
+# We use a local git repository for testing as getting the SHA of PR commits
+# is apparently a nightmare with GitHub plus it introduces a lot of extra
+# complexity.
+#
+# We want to set up a simple local repo we can always access and then confirm
+# the various configuration options for the git_config plugin work as expected.
+
+setupRepo() {
+    local repoDir=${1:-"$BATS_TEST_TMPDIR/repo"}
+    rm -rf "${repoDir:?}"/
+    mkdir -p "$repoDir"
+    pushd "$repoDir"
+        git init
+        git branch -m main
+        
+        git config user.name "Test User"
+        git config user.email "ignore@telemetryforge.io"
+
+        cp "$BATS_TEST_DIRNAME/resources/"*.yaml .
+        git add .
+        git commit -m "Initial commit"
+        echo "Made initial commit with SHA '$(git rev-parse HEAD)'"
+    popd
+}
+
+setup() {
+    # Remove any old instances
+    stopFluentBit
+
+    # Set up a local git repository with a simple config file we can use for testing
+    GIT_REPO_PATH="$BATS_TEST_TMPDIR/repo"
+    export GIT_REPO_PATH
+    setupRepo "$GIT_REPO_PATH"
+
+    # We will track the `main` branch
+    GIT_SHA="main"
+    export GIT_SHA
+    echo "Set up git repository at '$GIT_REPO_PATH'"
+}
+
+@test "verify git config plugin basic configuration" {
+    assert_file_exists "$BATS_TEST_DIRNAME/resources/initial-fluent-bit.yaml"
+    assert_file_exists "$BATS_TEST_DIRNAME/resources/fluent-bit.yaml"
+
+    # Verify the configuration files are valid and the plugin can start without errors with the provided configuration
+    run "$FLUENT_BIT_BINARY" -c "$BATS_TEST_DIRNAME/resources/initial-fluent-bit.yaml" --dry-run
+    assert_success
+    refute_output --partial "[error]"
+
+    # This is the one we should switch to after the first poll interval
+    run "$FLUENT_BIT_BINARY" -c "$BATS_TEST_DIRNAME/resources/fluent-bit.yaml" --dry-run
+    assert_success
+    refute_output --partial "[error]"
+
+    run "$FLUENT_BIT_BINARY" -c "$BATS_TEST_DIRNAME/resources/initial-fluent-bit.yaml"
+    assert_success
+    # Check we are correctly polling the repository and not encountering errors
+    refute_output --partial '[error]'
+    refute_output --partial 'failed to get remote SHA'
+    refute_output --partial 'failed to extract config file'
+    assert_output --partial 'new commit detected'
+    # The output should contain the message about switching to the updated configuration after the first poll interval
+    assert_output --partial 'Switched to updated configuration'
+}
+
+# Verify we can add a new commit to the repository and the plugin picks up the change without errors
+@test "verify git config plugin picks up new commits" {
+    # Verify the initial configuration is valid
+    assert_file_exists "$BATS_TEST_DIRNAME/resources/initial-fluent-bit-no-exit.yaml"
+
+    cat "$BATS_TEST_DIRNAME/resources/initial-fluent-bit-no-exit.yaml"
+
+    run "$FLUENT_BIT_BINARY" -c "$BATS_TEST_DIRNAME/resources/initial-fluent-bit-no-exit.yaml" --dry-run
+    assert_success
+    refute_output --partial "[error]"
+
+    # We run Fluent Bit with a config that does not have an exit explicitly
+    startFluentBit -c "$BATS_TEST_DIRNAME/resources/initial-fluent-bit-no-exit.yaml"
+
+    # Taken from the fluent-bit-no-exit.yaml file
+    local initialMessage="Dummy initial message"
+    local updatedMessage="Completely different configuration"
+
+    # We wait for the initial configuration to be applied and then we make a new commit
+    waitForOutput "$initialMessage" 30
+    markLogPosition
+
+    # Make a new commit to the repository with the updated configuration
+    pushd "$GIT_REPO_PATH"
+        sed -i "s/$initialMessage/$updatedMessage/" fluent-bit-no-exit.yaml
+        cat fluent-bit-no-exit.yaml
+        git add .
+        git commit -m "Update configuration"
+        echo "Made new commit with SHA '$(git rev-parse HEAD)'"
+    popd
+    
+    # We then check the output to confirm the new commit was detected and the configuration was switched to the updated one
+    waitForNewOutput "$updatedMessage" 30
+    markLogPosition
+
+    stopFluentBit
+}

--- a/testing/bats/tests/functional/plugins/verify-custom-plugins.bats
+++ b/testing/bats/tests/functional/plugins/verify-custom-plugins.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load "$HELPERS_ROOT/test-helpers.bash"
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_FILE_ROOT FLUENT_BIT_BINARY
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+load "$BATS_FILE_ROOT/load.bash"
+
+# bats file_tags=functional
+
+teardown() {
+    if [[ -n "${SKIP_TEARDOWN:-}" ]]; then
+        echo "Skipping teardown"
+    fi
+}
+
+@test "verify git_config plugin exists" {
+    run "$FLUENT_BIT_BINARY" --help
+    assert_success
+    assert_output --partial "git_config"
+    run "$FLUENT_BIT_BINARY" -C git_config --help
+    assert_success
+    refute_output --partial "[error]"
+}
+
+@test "verify custom telemetryforge plugin exists" {
+    run "$FLUENT_BIT_BINARY" --help
+    assert_success
+    assert_output --partial "telemetryforge"
+    run "$FLUENT_BIT_BINARY" -C "telemetryforge" --help
+    assert_success
+    refute_output --partial "[error]"
+}
+
+# Processors cannot be individually queried unfortunately like custom plugins so we just check for their existence in the help output
+@test "verify log_sampling processor exists" {
+    PLUGIN_NAME="log_sampling"
+    run "$FLUENT_BIT_BINARY" --help
+    assert_success
+    assert_output --partial "$PLUGIN_NAME"
+}
+
+@test "verify de-duplication processor exists" {
+    PLUGIN_NAME="dedup"
+    run "$FLUENT_BIT_BINARY" --help
+    assert_success
+    assert_output --partial "$PLUGIN_NAME"
+}
+

--- a/testing/bats/tests/integration/containers/integration-container-systemd.bats
+++ b/testing/bats/tests/integration/containers/integration-container-systemd.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+load "$HELPERS_ROOT/test-helpers.bash"
+
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_FILE_ROOT
+
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+load "$BATS_FILE_ROOT/load.bash"
+
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+
+# bats file_tags=integration,containers
+
+setup() {
+    skipIfNotContainer
+}
+
+@test "integration: verify we can run systemd input plugin with no issues" {
+    local journal_dir="/var/log/journal"
+    if [[ ! -d "$journal_dir" ]]; then
+        skip "Systemd journal directory does not exist, skipping test"
+    fi
+
+    # Ensure we do not trigger a segfault or errors when running the systemd input plugin
+    run "$CONTAINER_RUNTIME" run --rm -t \
+        --user=0 \
+        -v "$journal_dir":"$journal_dir":ro \
+        "${TELEMETRY_FORGE_AGENT_IMAGE}:${TELEMETRY_FORGE_AGENT_TAG}" \
+        -v -i systemd --prop="path=$journal_dir" -o exit --prop="time_count=10" -m '*' -o exit --prop="record_count=1" -m '*'
+    assert_success
+    refute_output --partial "SIGSEGV"
+    refute_output --partial "[error]"
+    refute_output --partial "[warn]"
+}

--- a/testing/bats/tests/integration/containers/integration-simple-containers.bats
+++ b/testing/bats/tests/integration/containers/integration-simple-containers.bats
@@ -16,16 +16,21 @@ setup() {
 }
 
 # All container tests use the environment variable TELEMETRY_FORGE_AGENT_IMAGE to determine which image to test
-@test "integration: verify TELEMETRY_FORGE_AGENT_IMAGE is set" {
+@test "integration: verify TELEMETRY_FORGE_AGENT_IMAGE/TAG is set" {
     [ -n "${TELEMETRY_FORGE_AGENT_IMAGE}" ]
     [ -n "${TELEMETRY_FORGE_AGENT_TAG}" ]
 }
 
 # Verify we can pull and run the TELEMETRY_FORGE_AGENT_IMAGE
-@test "integration: verify pulling and running TELEMETRY_FORGE_AGENT_IMAGE" {
+@test "integration: verify pulling ${TELEMETRY_FORGE_AGENT_IMAGE}:${TELEMETRY_FORGE_AGENT_TAG}" {
+    if [[ "$TELEMETRY_FORGE_AGENT_TAG" == "local" ]]; then
+        skip "TELEMETRY_FORGE_AGENT_TAG is set to local, skipping pull test"
+    fi
     run "$CONTAINER_RUNTIME" pull "${TELEMETRY_FORGE_AGENT_IMAGE}:${TELEMETRY_FORGE_AGENT_TAG}"
     assert_success
+}
 
+@test "integration: verify we can run the agent image and get version output" {
     run "$CONTAINER_RUNTIME" run --rm -t "${TELEMETRY_FORGE_AGENT_IMAGE}:${TELEMETRY_FORGE_AGENT_TAG}" --version
     assert_success
     assert_output --partial "Telemetry Forge Agent v$TELEMETRY_FORGE_AGENT_VERSION"

--- a/testing/bats/tests/integration/linux/integration-install-script.bats
+++ b/testing/bats/tests/integration/linux/integration-install-script.bats
@@ -33,10 +33,16 @@ setupFile() {
     [ -n "$TELEMETRY_FORGE_AGENT_URL" ]
 }
 
+# If you hit failures with the install script then verify the Cloudflare Bot or security rules
+# are not preventing access to the index.html page at the root of the repo.
+
 # Test that we can fetch the top-level index
 @test "integration: can access index at $TELEMETRY_FORGE_AGENT_URL/index.html" {
     response=$(curl --max-time 60 -s -o /dev/null -w "%{http_code}" "$TELEMETRY_FORGE_AGENT_URL/index.html")
-    [ "$response" = "200" ]
+    if [ "$response" != "200" ]; then
+        echo "Failure may be related to Cloudflare bot detection or security rules preventing access to the index.html."
+        fail "Failed to access $TELEMETRY_FORGE_AGENT_URL/index.html - HTTP status code: $response"
+    fi
 }
 
 # Test the we have an install script at the root of the repo


### PR DESCRIPTION
Backport of #318 to the 26.4 LTS series.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures we build the `telemetryforge` agent registration plugin on 26.4 LTS and updates the container/runtime so `git_config` and custom processors build and run reliably, with new tests covering plugin behavior and container paths.

- **Bug Fixes**
  - Renamed CMake options to `FLB_CUSTOM_TELEMETRYFORGE` and `FLB_IN_TELEMETRYFORGE` to match expected identifiers.
  - Updated `Dockerfile.ubi`: move to UBI 9.7, prefer system `zstd` (`-DFLB_PREFER_SYSTEM_LIB_ZSTD=On`), add `libzstd`/`zstd`, fix `libssh2` ldconfig paths, and include `git` for `git_config` tests.

- **Tests**
  - Added helpers (`startFluentBit`, `markLogPosition`, `waitForOutput`, `waitForNewOutput`, `stopFluentBit`) and functional tests for `git_config` polling and config switching.
  - Added checks for `telemetryforge`, `git_config`, `log_sampling`, and `dedup`.
  - Added container integration tests for agent image/tag and the systemd input plugin; improved install script messaging when index access fails.

<sup>Written for commit 08698d57d2bb4835d7853585d8ad666d88bf3065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/telemetryforge/agent/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

