### PR TITLE
ci: add s390x container build support

### DIFF
--- a/.github/workflows/call-build-containers.yaml
+++ b/.github/workflows/call-build-containers.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: "namespace-profile-ubuntu-latest-arm"
+      s390x-runner-label:
+        description: The label to use for the runner (if not specified then the default ubuntu-latest or equivalent is used).
+        required: false
+        type: string
+        default: "ubuntu-24.04-s390x"
     secrets:
       cosign_private_key:
         description: The optional Cosign key to use for signing the images.
@@ -75,10 +80,11 @@ jobs:
         platform:
           - amd64
           - arm64
+          - s390x
         target:
           - production
     name: ${{ matrix.platform }}/${{ matrix.target }} container image build
-    runs-on: ${{ (contains(matrix.platform, 'arm') && inputs.arm-runner-label) || inputs.amd-runner-label }}
+    runs-on: ${{ (contains(matrix.platform, 'arm') && inputs.arm-runner-label) || (contains(matrix.platform, 's390x') && inputs.s390x-runner-label) || inputs.amd-runner-label }}
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -104,7 +110,7 @@ jobs:
 
       # Must be removed on Namespace runners
       - name: Set up QEMU
-        if: ${{ !contains( runner.name, 'nsc-' ) }}
+        if: ${{ !(contains( runner.name, 'nsc-' ) || contains( matrix.platform, 's390x' )) }}
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Related to https://github.com/IBM/actionspz/issues/115

Uses IBM-provided s390x runners to do the build for that architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add s390x container build support in CI using IBM-provided s390x runners. Builds native s390x images alongside amd64 and arm64 and skips QEMU for s390x.

- **New Features**
  - Added `s390x` to the build matrix and an optional `s390x-runner-label` input (default `ubuntu-24.04-s390x`) with runner selection logic.
  - Skipped QEMU when building on s390x.

<sup>Written for commit d1d022c781a13f6eb4d9955c2d2054be4ef90044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/telemetryforge/agent/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

